### PR TITLE
fix: correctly match on everything

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "namespace": "https://olivierdagenais.github.io/",
     "license": "https://opensource.org/licenses/MIT",
     "match": [
-      "*"
+      "*://*/*"
     ],
     "connect": [],
     "require": [


### PR DESCRIPTION
It turns out that `@match *` didn't actually match "everything" and ultimately, `@match *://*/*` did.