### PR TITLE
feat: Improve the clipboard capabilties

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 A Tampermonkey userscript to copy nice-looking URLs to the clipboard.
 
+## Installation
+
+1. First, you need to install the Tampermonkey extension for your browser, which can be found at: <https://www.tampermonkey.net/>
+1. If you are using Firefox, follow the one-time configuration in the sub-section below.
+1. You have to decide whether you want to always track the latest version (known as the `live` branch) or one of the release branches (which start with `release/`).  Go to <https://github.com/olivierdagenais/tampermonkey-copy-url/branches> and make your choice.
+1. Navigate to the `userscript/index.user.js` file.
+1. Activate the **Raw** link.  Tampermonkley should detect that a UserScript is there and prompt you to install it.
+1. Tampermonkey will check for updates and prompt you to upgrade when a new version is released.
+
+### Firefox one-time configuration
+
+Since version 87, Firefox's Clipboard API is disabled by default and will result in an error like:
+
+> Uncaught ReferenceError: ClipboardItem is not defined
+
+Clipboard support can be enabled by following these steps:
+
+1. Open a new tab and navigate to about:config
+2. Find the `dom.events.asyncClipboard.clipboardItem` item and set it to **true**.
+
 ## Development
 
 1. Install dependencies with `npm install` or `npm ci`.

--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
     "connect": [],
     "require": [
     ],
-    "grant": [
-      "GM_setClipboard"
-    ],
+    "grant": [],
     "exclude": [],
     "resources": []
   }

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,7 +1,4 @@
-// These are the details needed to invoke GM_setClipboard();
 export type Clipboard = {
-    data: string;
-    // can be an object like "{ type: 'text', mimetype: 'text/plain'}"
-    // or just a string expressing the type ("text" or "html").
-    typeInfo: any;
+    text: string;
+    html: string | null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,36 @@ function handleKeydown(this: Window, e: KeyboardEvent) {
             console.log('rendering Textile...');
             clipboard = renderers[2].render(link);
         }
-        GM_setClipboard(clipboard.data, clipboard.typeInfo);
+        var clipboardItemVersions : {[id:string]: Blob;} = {};
+        clipboardItemVersions["text/plain"] = new Blob(
+            [
+                clipboard.text
+            ],
+            {
+                type: "text/plain",
+            },
+        );
+
+        if (clipboard.html !== null) {
+            clipboardItemVersions["text/html"] = new Blob(
+                [
+                    clipboard.html
+                ],
+                {
+                    type: "text/html",
+                },
+            );
+        }
+        const clipboardItem = new ClipboardItem(clipboardItemVersions);
+        const data = [clipboardItem];
+        navigator.clipboard.write(data).then(
+            () => {
+                console.log("Success")
+            },
+            (e) => {
+                console.log(`Failure: ${e}`)
+            }
+        );
     }
 }
 

--- a/src/renderers/Html.spec.ts
+++ b/src/renderers/Html.spec.ts
@@ -12,5 +12,6 @@ test('should render a simple link', () => {
 
     const actual : Clipboard = cut.render(link);
 
-    assert.equal(actual.data, '<a href="https://www.example.com">example</a>');
+    assert.equal(actual.text, 'example');
+    assert.equal(actual.html, '<a href="https://www.example.com">example</a>');
 })

--- a/src/renderers/Html.ts
+++ b/src/renderers/Html.ts
@@ -5,8 +5,8 @@ import { Renderer } from "../Renderer";
 export class Html implements Renderer {
     render(link: Link): Clipboard {
         let result : Clipboard = {
-            data: `<a href="${link.destination}">${link.text}</a>`,
-            typeInfo: "html",
+            text: link.text,
+            html: `<a href="${link.destination}">${link.text}</a>`,
         };
         return result;
     }

--- a/src/renderers/Markdown.spec.ts
+++ b/src/renderers/Markdown.spec.ts
@@ -12,5 +12,5 @@ test('should render a simple link', () => {
 
     const actual : Clipboard = cut.render(link);
 
-    assert.equal(actual.data, "[example](https://www.example.com)");
+    assert.equal(actual.text, "[example](https://www.example.com)");
 })

--- a/src/renderers/Markdown.ts
+++ b/src/renderers/Markdown.ts
@@ -5,8 +5,8 @@ import { Renderer } from "../Renderer";
 export class Markdown implements Renderer {
     render(link: Link): Clipboard {
         let result : Clipboard = {
-            data: `[${link.text}](${link.destination})`,
-            typeInfo: "text"
+            text: `[${link.text}](${link.destination})`,
+            html: null,
         };
         return result;
     }

--- a/src/renderers/Textile.spec.ts
+++ b/src/renderers/Textile.spec.ts
@@ -12,5 +12,5 @@ test('should render a simple link', () => {
 
     const actual : Clipboard = cut.render(link);
 
-    assert.equal(actual.data, '[example|https://www.example.com]');
+    assert.equal(actual.text, '[example|https://www.example.com]');
 })

--- a/src/renderers/Textile.ts
+++ b/src/renderers/Textile.ts
@@ -5,8 +5,8 @@ import { Renderer } from "../Renderer";
 export class Textile implements Renderer {
     render(link: Link): Clipboard {
         let result : Clipboard = {
-            data: `[${link.text}|${link.destination}]`,
-            typeInfo: "text"
+            text: `[${link.text}|${link.destination}]`,
+            html: null,
         };
         return result;
     }


### PR DESCRIPTION
By switching to the [Clipboard API](https://www.w3.org/TR/clipboard-apis/#dom-clipboard-write), we can send richer content to the clipboard, such as dual HTML and plain-text fallback.

# Manual testing

## Given

A page that has a `<title>` element, such as https://example.com

## When

I hit `Ctrl+O`.

## Then

The contents of the clipboard will be:
| Type | Content                                              |
| ---- | ---------------------------------------------------- |
| HTML | `<a href="https://example.com/">Example Domain</a>` |
| text | `Example Domain`                                     | 

...which I verified by pasting in various text boxes/editors, which of which allowed me to see the HTML versions while others only supported the plain text version.

Mission accomplished!