### PR TITLE
style: add prettier and re-format accordingly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,30 @@
 name: Test, package
 
 on:
-  push:
-  pull_request:
-    branches:
-      - "main"
-      - "release/*"
+    push:
+    pull_request:
+        branches:
+            - "main"
+            - "release/*"
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+    build:
+        runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
+        steps:
+            - uses: actions/checkout@v2
 
-    - name: Install Node.JS
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16
-        registry-url: https://registry.npmjs.org/
+            - name: Install Node.JS
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16
+                  registry-url: https://registry.npmjs.org/
 
-    - name: Install dependencies
-      run: npm install
+            - name: Install dependencies
+              run: npm install
 
-    - name: Run tests
-      run: npm test
-    
-    - name: Package to Javascript bundle
-      run: npm run build
+            - name: Run tests
+              run: npm test
+
+            - name: Package to Javascript bundle
+              run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "bracketSameLine": true,
+    "endOfLine": "crlf",
+    "tabWidth": 4,
+    "useTabs": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,11 +9,7 @@
             "command": "./docker_node npm test",
             "windows": {
                 "command": "wsl",
-                "args": [
-                    "bash",
-                    "-c",
-                    "./docker_node npm test",
-                ],
+                "args": ["bash", "-c", "./docker_node npm test"]
             },
             "presentation": {
                 "echo": true,
@@ -21,12 +17,12 @@
                 "focus": true,
                 "panel": "shared",
                 "showReuseMessage": true,
-                "clear": true,
+                "clear": true
             },
             "problemMatcher": [],
             "group": {
                 "kind": "test",
-                "isDefault": true,
+                "isDefault": true
             }
         },
         {
@@ -35,11 +31,7 @@
             "command": "./docker_node npm run build",
             "windows": {
                 "command": "wsl",
-                "args": [
-                    "bash",
-                    "-c",
-                    "./docker_node npm run build",
-                ],
+                "args": ["bash", "-c", "./docker_node npm run build"]
             },
             "presentation": {
                 "echo": true,
@@ -47,13 +39,13 @@
                 "focus": true,
                 "panel": "shared",
                 "showReuseMessage": true,
-                "clear": true,
+                "clear": true
             },
             "problemMatcher": [],
             "group": {
                 "kind": "build",
-                "isDefault": true,
+                "isDefault": true
             }
-        },
+        }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A Tampermonkey userscript to copy nice-looking URLs to the clipboard.
 
 1. First, you need to install the Tampermonkey extension for your browser, which can be found at: <https://www.tampermonkey.net/>
 1. If you are using Firefox, follow the one-time configuration in the sub-section below.
-1. You have to decide whether you want to always track the latest version (known as the `live` branch) or one of the release branches (which start with `release/`).  Go to <https://github.com/olivierdagenais/tampermonkey-copy-url/branches> and make your choice.
+1. You have to decide whether you want to always track the latest version (known as the `live` branch) or one of the release branches (which start with `release/`). Go to <https://github.com/olivierdagenais/tampermonkey-copy-url/branches> and make your choice.
 1. Navigate to the `userscript/index.user.js` file.
-1. Activate the **Raw** link.  Tampermonkley should detect that a UserScript is there and prompt you to install it.
+1. Activate the **Raw** link. Tampermonkley should detect that a UserScript is there and prompt you to install it.
 1. Tampermonkey will check for updates and prompt you to upgrade when a new version is released.
 
 ### Firefox one-time configuration
@@ -31,7 +31,7 @@ Clipboard support can be enabled by following these steps:
 
 ### Using the [Node.js container](https://github.com/nodejs/docker-node/blob/main/README.md)
 
-To avoid having to install anything (except the Docker Engine CLI!), just prefix any `node` or `npm` command with `./docker_node`.  For example: `./docker_node npm install`
+To avoid having to install anything (except the Docker Engine CLI!), just prefix any `node` or `npm` command with `./docker_node`. For example: `./docker_node npm install`
 
 ### Debug
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,12 @@
 // Inspired from https://dev.to/muhajirdev/unit-testing-with-typescript-and-jest-2gln
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  roots: ['<rootDir>/src'],
-  transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
-  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+    roots: ["<rootDir>/src"],
+    transform: {
+        "^.+\\.tsx?$": "ts-jest",
+    },
+    testRegex: "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+    preset: "ts-jest",
+    testEnvironment: "node",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "jest": "^27.4.7",
         "jsdom": "^19.0.0",
         "package-json-io": "1.0.0",
+        "prettier": "^2.7.1",
         "ts-jest": "^27.1.3",
         "ts-loader": "^9.2.6",
         "ts-node": "^10.4.0",
@@ -4126,6 +4127,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -8480,6 +8496,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jest": "^27.4.7",
     "jsdom": "^19.0.0",
     "package-json-io": "1.0.0",
+    "prettier": "^2.7.1",
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -1,53 +1,52 @@
 {
-  "name": "tampermonkey-copy-url",
-  "version": "1.0.0",
-  "description": "A Tampermonkey userscript to copy nice-looking URLs to the clipboard.",
-  "main": "userscript/index.user.js",
-  "scripts": {
-    "test": "jest",
-    "setUrls": "node setUrls.js",
-    "build": "webpack"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/olivierdagenais/tampermonkey-copy-url.git"
-  },
-  "keywords": [],
-  "author": "Olivier Dagenais",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/olivierdagenais/tampermonkey-copy-url/issues"
-  },
-  "homepage": "https://github.com/olivierdagenais/tampermonkey-copy-url",
-  "devDependencies": {
-    "@types/jest": "^27.4.0",
-    "@types/jsdom": "^16.2.14",
-    "@types/node": "^16.11.10",
-    "@types/tampermonkey": "^4.0.5",
-    "@types/webpack": "^5.28.0",
-    "jest": "^27.4.7",
-    "jsdom": "^19.0.0",
-    "package-json-io": "1.0.0",
-    "prettier": "^2.7.1",
-    "ts-jest": "^27.1.3",
-    "ts-loader": "^9.2.6",
-    "ts-node": "^10.4.0",
-    "typescript": "^4.5.2",
-    "webpack": "^5.64.3",
-    "webpack-cli": "^4.9.1"
-  },
-  "userscript": {
-    "require-template": "https://cdn.jsdelivr.net/npm/${dependencyName}@${dependencyVersion}",
-    "namespace": "https://olivierdagenais.github.io/",
-    "license": "https://opensource.org/licenses/MIT",
-    "match": [
-      "*://*/*"
-    ],
-    "connect": [],
-    "require": [
-    ],
-    "grant": [],
-    "exclude": [],
-    "resources": []
-  }
+    "name": "tampermonkey-copy-url",
+    "version": "1.0.0",
+    "description": "A Tampermonkey userscript to copy nice-looking URLs to the clipboard.",
+    "main": "userscript/index.user.js",
+    "scripts": {
+        "test": "jest",
+        "setUrls": "node setUrls.js",
+        "build": "webpack"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/olivierdagenais/tampermonkey-copy-url.git"
+    },
+    "keywords": [],
+    "author": "Olivier Dagenais",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/olivierdagenais/tampermonkey-copy-url/issues"
+    },
+    "homepage": "https://github.com/olivierdagenais/tampermonkey-copy-url",
+    "devDependencies": {
+        "@types/jest": "^27.4.0",
+        "@types/jsdom": "^16.2.14",
+        "@types/node": "^16.11.10",
+        "@types/tampermonkey": "^4.0.5",
+        "@types/webpack": "^5.28.0",
+        "jest": "^27.4.7",
+        "jsdom": "^19.0.0",
+        "package-json-io": "1.0.0",
+        "prettier": "^2.7.1",
+        "ts-jest": "^27.1.3",
+        "ts-loader": "^9.2.6",
+        "ts-node": "^10.4.0",
+        "typescript": "^4.5.2",
+        "webpack": "^5.64.3",
+        "webpack-cli": "^4.9.1"
+    },
+    "userscript": {
+        "require-template": "https://cdn.jsdelivr.net/npm/${dependencyName}@${dependencyVersion}",
+        "namespace": "https://olivierdagenais.github.io/",
+        "license": "https://opensource.org/licenses/MIT",
+        "match": [
+            "*://*/*"
+        ],
+        "connect": [],
+        "require": [],
+        "grant": [],
+        "exclude": [],
+        "resources": []
+    }
 }

--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -1,10 +1,10 @@
-import p from '../package.json';
+import p from "../package.json";
 
 /**
  * Userscript's all headers.
  */
 interface UserScriptOptions {
-    'require-template': string;
+    "require-template": string;
     name: string;
     namespace: string;
     description: string;
@@ -28,7 +28,7 @@ interface UserScriptOptions {
     require: string[];
     resources: string[];
     connect: string[];
-    'run-at': string;
+    "run-at": string;
     grant: string[];
     antifeature: string[];
     noframes: boolean;
@@ -53,33 +53,34 @@ const userscript = packageJson.userscript as Partial<UserScriptOptions>;
 
 /**
  * Generate a userscript's headers from "package.json" file.
- * 
+ *
  * @returns {string} Return userscript's header.
  */
 export function generateHeader() {
-
     // The regular expression used to remove the dependency version string prefix.
     const dependencyVersionRegExp = /^[\^~]/;
     // Userscript's header.
-    const headers = ['// ==UserScript=='];
+    const headers = ["// ==UserScript=="];
 
     /**
-     * Add userscript header's name. 
+     * Add userscript header's name.
      * If the name is not set, the package name is used. If neither is set, an error is thrown.
      */
     if (packageJson.name || userscript.name) {
         headers.push(`// @name ${userscript.name ?? packageJson.name}`);
     } else {
-        throw new Error('No name specified in package.json');
+        throw new Error("No name specified in package.json");
     }
     /**
-     * Add userscript header's version. 
+     * Add userscript header's version.
      * If the version is not set, the package version is used. If neither is set, an error is thrown.
      */
     if (packageJson.version || userscript.version) {
-        headers.push(`// @version ${userscript.version ?? packageJson.version}`);
+        headers.push(
+            `// @version ${userscript.version ?? packageJson.version}`
+        );
     } else {
-        throw new Error('No version specified in package.json');
+        throw new Error("No version specified in package.json");
     }
     // Add userscript header's namespace.
     if (userscript.namespace) {
@@ -87,7 +88,11 @@ export function generateHeader() {
     }
     // Add userscript header's description.
     if (packageJson.description || userscript.description) {
-        headers.push(`// @description ${userscript.description ?? packageJson.description}`);
+        headers.push(
+            `// @description ${
+                userscript.description ?? packageJson.description
+            }`
+        );
     }
     // Add userscript header's author.
     if (packageJson.author || userscript.author) {
@@ -95,7 +100,9 @@ export function generateHeader() {
     }
     // Add userscript header's homepage, homepageURL, website or source.
     if (packageJson.homepage || userscript.homepage) {
-        headers.push(`// @homepage ${userscript.homepage ?? packageJson['homepage']}`);
+        headers.push(
+            `// @homepage ${userscript.homepage ?? packageJson["homepage"]}`
+        );
     } else if (userscript.homepageURL) {
         headers.push(`// @homepageURL ${userscript.homepageURL}`);
     } else if (userscript.website) {
@@ -149,20 +156,24 @@ export function generateHeader() {
     }
     /**
      * Add userscript header's requires.
-     * The package name and version will be obtained from the "dependencies" field, 
+     * The package name and version will be obtained from the "dependencies" field,
      * and the jsdelivr link will be generated automatically.
-     * You can also set the string template with the parameters "{dependencyName}" and "{dependencyVersion}" 
+     * You can also set the string template with the parameters "{dependencyName}" and "{dependencyVersion}"
      * in the "require-template" field of the "userscript" object in the "package.json" file.
      */
     if (packageJson.dependencies) {
-        const urlTemplate = userscript['require-template'] ?? 'https://cdn.jsdelivr.net/npm/{dependencyName}@{dependencyVersion}';
+        const urlTemplate =
+            userscript["require-template"] ??
+            "https://cdn.jsdelivr.net/npm/{dependencyName}@{dependencyVersion}";
         const requireTemplate = `// @require ${urlTemplate}`;
         for (const dependencyName in packageJson.dependencies) {
-            const dependencyVersion = packageJson.dependencies[dependencyName].replace(dependencyVersionRegExp, '');
+            const dependencyVersion = packageJson.dependencies[
+                dependencyName
+            ].replace(dependencyVersionRegExp, "");
             headers.push(
                 requireTemplate
-                    .replace('{dependencyName}', dependencyName)
-                    .replace('{dependencyVersion}', dependencyVersion)
+                    .replace("{dependencyName}", dependencyName)
+                    .replace("{dependencyVersion}", dependencyVersion)
             );
         }
     }
@@ -185,8 +196,8 @@ export function generateHeader() {
         }
     }
     // Add userscript header's run-at.
-    if (userscript['run-at']) {
-        headers.push(`// @run-at ${userscript['run-at']}`);
+    if (userscript["run-at"]) {
+        headers.push(`// @run-at ${userscript["run-at"]}`);
     }
     // Add userscript header's grants.
     if (userscript.grant && userscript.grant instanceof Array) {
@@ -202,13 +213,13 @@ export function generateHeader() {
     }
     // Add userscript header's noframes.
     if (userscript.noframes) {
-        headers.push('// @noframes');
+        headers.push("// @noframes");
     }
     // Add userscript header's nocompat.
     if (userscript.nocompat) {
         headers.push(`// @nocompat ${userscript.nocompat}`);
     }
     // Userscript header's ending.
-    headers.push('// ==/UserScript==\n')
-    return headers.join('\n');
+    headers.push("// ==/UserScript==\n");
+    return headers.join("\n");
 }

--- a/setUrls.js
+++ b/setUrls.js
@@ -1,19 +1,18 @@
-var pkg = require('package-json-io')
+var pkg = require("package-json-io");
 
 // read and parse the package.json file in current directory
 pkg.read(function (err, data) {
-  const args = process.argv;
-  if (args.length >= 3) {
-    const url = `https://github.com/olivierdagenais/tampermonkey-copy-url/raw/${args[2]}/userscript/index.user.js`;
-    data.userscript.downloadURL = url;
-    data.userscript.updateURL = url;
-  }
-  else {
-    delete data.userscript.downloadURL
-    delete data.userscript.updateURL
-  }
-  // update the package.json file in the current directory
-  pkg.update(data, function (err) {
-    if (err) throw err
-  })
-})
+    const args = process.argv;
+    if (args.length >= 3) {
+        const url = `https://github.com/olivierdagenais/tampermonkey-copy-url/raw/${args[2]}/userscript/index.user.js`;
+        data.userscript.downloadURL = url;
+        data.userscript.updateURL = url;
+    } else {
+        delete data.userscript.downloadURL;
+        delete data.userscript.updateURL;
+    }
+    // update the package.json file in the current directory
+    pkg.update(data, function (err) {
+        if (err) throw err;
+    });
+});

--- a/src/Clipboard.ts
+++ b/src/Clipboard.ts
@@ -1,4 +1,4 @@
 export type Clipboard = {
     text: string;
     html: string | null;
-}
+};

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -2,4 +2,4 @@
 export type Link = {
     text: string;
     destination: string;
-}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,68 +9,53 @@ import { Renderer } from "./Renderer";
 import { Textile } from "./renderers/Textile";
 import { Parser } from "./Parser";
 
-const renderers : Renderer[] = [
-    new Html(),
-    new Markdown(),
-    new Textile(),
-];
+const renderers: Renderer[] = [new Html(), new Markdown(), new Textile()];
 
 // parsers will be attempted in the order defined here
-const parsers : Parser[] = [
+const parsers: Parser[] = [
     new GitHub(),
     // always keep this one LAST in this list!
     new Default(),
 ];
 
-var statusPopup : HTMLDivElement | null;
+var statusPopup: HTMLDivElement | null;
 
 function handleKeydown(this: Window, e: KeyboardEvent) {
     if (e.ctrlKey && e.key == "o") {
         e.preventDefault();
-        console.log('asking the parsers...');
-        const document : Document = window.document;
-        const url : string = window.location.href;
-        var link : Link = {
+        console.log("asking the parsers...");
+        const document: Document = window.document;
+        const url: string = window.location.href;
+        var link: Link = {
             text: url,
             destination: url,
         };
-        var selectedParser : Parser = parsers[parsers.length - 1];
+        var selectedParser: Parser = parsers[parsers.length - 1];
         for (let i = 0; i < parsers.length; i++) {
             const parser = parsers[i];
             selectedParser = parser;
-            var candidate : Link | null = parser.parseLink(document, url);
+            var candidate: Link | null = parser.parseLink(document, url);
             if (candidate) {
                 link = candidate;
                 break;
             }
         }
-        var selectedRenderer : Renderer = renderers[0];
+        var selectedRenderer: Renderer = renderers[0];
         if (!e.altKey) {
             selectedRenderer = renderers[0];
-        }
-        else {
+        } else {
             selectedRenderer = renderers[2];
         }
         const clipboard: Clipboard = selectedRenderer.render(link);
-        var clipboardItemVersions : {[id:string]: Blob;} = {};
-        clipboardItemVersions["text/plain"] = new Blob(
-            [
-                clipboard.text
-            ],
-            {
-                type: "text/plain",
-            },
-        );
+        var clipboardItemVersions: { [id: string]: Blob } = {};
+        clipboardItemVersions["text/plain"] = new Blob([clipboard.text], {
+            type: "text/plain",
+        });
 
         if (clipboard.html !== null) {
-            clipboardItemVersions["text/html"] = new Blob(
-                [
-                    clipboard.html
-                ],
-                {
-                    type: "text/html",
-                },
-            );
+            clipboardItemVersions["text/html"] = new Blob([clipboard.html], {
+                type: "text/html",
+            });
         }
 
         if (statusPopup == null) {
@@ -90,10 +75,11 @@ function handleKeydown(this: Window, e: KeyboardEvent) {
             document.body.appendChild(statusPopup);
         }
         const clipboardItem = new ClipboardItem(clipboardItemVersions);
-        const status = `Parsed using ${selectedParser.constructor['name']}:`
-            + `<br />Destination: ${link.destination}`
-            + `<br />Text: ${link.text}`
-            + `<br />Rendered with ${selectedRenderer.constructor['name']}.`;
+        const status =
+            `Parsed using ${selectedParser.constructor["name"]}:` +
+            `<br />Destination: ${link.destination}` +
+            `<br />Text: ${link.text}` +
+            `<br />Rendered with ${selectedRenderer.constructor["name"]}.`;
         const data = [clipboardItem];
         navigator.clipboard.write(data).then(
             () => {
@@ -101,8 +87,9 @@ function handleKeydown(this: Window, e: KeyboardEvent) {
                 showStatusPopup(successHtml);
             },
             (e) => {
-                const failureHtml = `${status}<br />`
-                    + `<span style="color:darkred">Failure: ${e}</span>`;
+                const failureHtml =
+                    `${status}<br />` +
+                    `<span style="color:darkred">Failure: ${e}</span>`;
                 showStatusPopup(failureHtml);
             }
         );
@@ -131,4 +118,3 @@ async function main(): Promise<void> {
 }
 
 main();
-

--- a/src/parsers/Default.spec.ts
+++ b/src/parsers/Default.spec.ts
@@ -4,7 +4,7 @@ import { Link } from "../Link";
 import { Parser } from "../Parser";
 import { Default } from "./Default";
 
-test('should parse a simple HTML page', () => {
+test("should parse a simple HTML page", () => {
     const html = `
     <html><head>
     <title>Example Domain</title>
@@ -20,18 +20,18 @@ test('should parse a simple HTML page', () => {
 
 
 </body></html>`;
-    const dom : JSDOM = new JSDOM(html);
-    const document : Document = dom.window.document;
-    const cut : Parser = new Default();
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Default();
 
-    const actual : Link | null = cut.parseLink(document, "https://example.com");
+    const actual: Link | null = cut.parseLink(document, "https://example.com");
 
     assert.notEqual(actual, null);
     assert.equal(actual?.destination, "https://example.com");
     assert.equal(actual?.text, "Example Domain");
-})
+});
 
-test('should parse a page without a title', () => {
+test("should parse a page without a title", () => {
     const html = `
     <html><head>
 </head>
@@ -46,13 +46,13 @@ test('should parse a page without a title', () => {
 
 
 </body></html>`;
-    const dom : JSDOM = new JSDOM(html);
-    const document : Document = dom.window.document;
-    const cut : Parser = new Default();
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Default();
 
-    const actual : Link | null = cut.parseLink(document, "https://example.com");
+    const actual: Link | null = cut.parseLink(document, "https://example.com");
 
     assert.notEqual(actual, null);
     assert.equal(actual?.destination, "https://example.com");
     assert.equal(actual?.text, "https://example.com");
-})
+});

--- a/src/parsers/Default.ts
+++ b/src/parsers/Default.ts
@@ -3,8 +3,9 @@ import { Parser } from "../Parser";
 
 export class Default implements Parser {
     parseLink(doc: Document, url: string): Link | null {
-        const titleElement : HTMLElement | null = doc.querySelector("html head title");
-        const result : Link = {
+        const titleElement: HTMLElement | null =
+            doc.querySelector("html head title");
+        const result: Link = {
             text: titleElement?.textContent ?? url,
             destination: url,
         };

--- a/src/parsers/GitHub.spec.ts
+++ b/src/parsers/GitHub.spec.ts
@@ -4,16 +4,16 @@ import { Link } from "../Link";
 import { Parser } from "../Parser";
 import { GitHub } from "./GitHub";
 
-function testParseLink(html: string, url: string) : Link | null {
-    const dom : JSDOM = new JSDOM(html);
-    const document : Document = dom.window.document;
-    const cut : Parser = new GitHub();
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new GitHub();
 
-    const actual : Link | null = cut.parseLink(document, url);
+    const actual: Link | null = cut.parseLink(document, url);
     return actual;
 }
 
-test('should parse a simple GitHub repository link', () => {
+test("should parse a simple GitHub repository link", () => {
     const html = `
 <html>
     <head>
@@ -34,10 +34,13 @@ test('should parse a simple GitHub repository link', () => {
 
     assert.notEqual(actual, null);
     assert.equal(actual?.destination, "https://github.com/jsdom/jsdom");
-    assert.equal(actual?.text, "jsdom/jsdom: A JavaScript implementation of various web standards, for use with Node.js");
-})
+    assert.equal(
+        actual?.text,
+        "jsdom/jsdom: A JavaScript implementation of various web standards, for use with Node.js"
+    );
+});
 
-test('should parse a simple GitHub pull request page', () => {
+test("should parse a simple GitHub pull request page", () => {
     const html = `
 <html>
     <head>
@@ -45,14 +48,23 @@ test('should parse a simple GitHub pull request page', () => {
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4");
+    const actual = testParseLink(
+        html,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4");
-    assert.equal(actual?.text, "olivierdagenais/tampermonkey-copy-url#4: feat: Improve the clipboard capabilities by olivierdagenais");
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4"
+    );
+    assert.equal(
+        actual?.text,
+        "olivierdagenais/tampermonkey-copy-url#4: feat: Improve the clipboard capabilities by olivierdagenais"
+    );
+});
 
-test('should parse a GitHub pull request page with a deep link', () => {
+test("should parse a GitHub pull request page with a deep link", () => {
     const html = `
 <html>
     <head>
@@ -60,14 +72,23 @@ test('should parse a GitHub pull request page with a deep link', () => {
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4/commits/98f37a494d7611668adf410163133167b827e721#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14");
+    const actual = testParseLink(
+        html,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4/commits/98f37a494d7611668adf410163133167b827e721#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4/commits/98f37a494d7611668adf410163133167b827e721#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14");
-    assert.equal(actual?.text, "olivierdagenais/tampermonkey-copy-url#4: feat: Improve the clipboard capabilities by olivierdagenais");
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/pull/4/commits/98f37a494d7611668adf410163133167b827e721#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14"
+    );
+    assert.equal(
+        actual?.text,
+        "olivierdagenais/tampermonkey-copy-url#4: feat: Improve the clipboard capabilities by olivierdagenais"
+    );
+});
 
-test('should parse a GitHub discussion page', () => {
+test("should parse a GitHub discussion page", () => {
     const html = `
 <html>
     <head>
@@ -75,14 +96,23 @@ test('should parse a GitHub discussion page', () => {
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/microsoft/WSL/discussions/6128");
+    const actual = testParseLink(
+        html,
+        "https://github.com/microsoft/WSL/discussions/6128"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/microsoft/WSL/discussions/6128");
-    assert.equal(actual?.text, "microsoft/WSL#6128: How to execute WSL commands from a windows batch file?");
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/microsoft/WSL/discussions/6128"
+    );
+    assert.equal(
+        actual?.text,
+        "microsoft/WSL#6128: How to execute WSL commands from a windows batch file?"
+    );
+});
 
-test('should parse a GitHub issue page', () => {
+test("should parse a GitHub issue page", () => {
     const html = `
 <html>
     <head>
@@ -90,14 +120,23 @@ test('should parse a GitHub issue page', () => {
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/jenkinsci/stapler/issues/219");
+    const actual = testParseLink(
+        html,
+        "https://github.com/jenkinsci/stapler/issues/219"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/jenkinsci/stapler/issues/219");
-    assert.equal(actual?.text, "jenkinsci/stapler#219: Nondeterministic output of processors");
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/jenkinsci/stapler/issues/219"
+    );
+    assert.equal(
+        actual?.text,
+        "jenkinsci/stapler#219: Nondeterministic output of processors"
+    );
+});
 
-test('should parse a GitHub source code link page', () => {
+test("should parse a GitHub source code link page", () => {
     const html = `
 <html>
     <head>
@@ -105,14 +144,23 @@ test('should parse a GitHub source code link page', () => {
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/main/src/index.ts");
+    const actual = testParseLink(
+        html,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/main/src/index.ts"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/main/src/index.ts");
-    assert.equal(actual?.text, "src/index.ts at main in olivierdagenais/tampermonkey-copy-url")
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/main/src/index.ts"
+    );
+    assert.equal(
+        actual?.text,
+        "src/index.ts at main in olivierdagenais/tampermonkey-copy-url"
+    );
+});
 
-test('should parse a GitHub source code link page with refSpec containing a slash', () => {
+test("should parse a GitHub source code link page with refSpec containing a slash", () => {
     const html = `
 <html>
     <head>
@@ -120,9 +168,18 @@ test('should parse a GitHub source code link page with refSpec containing a slas
     </head>
 </html>`;
 
-    const actual = testParseLink(html, "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/release/1.1/src/index.ts");
+    const actual = testParseLink(
+        html,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/release/1.1/src/index.ts"
+    );
 
     assert.notEqual(actual, null);
-    assert.equal(actual?.destination, "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/release/1.1/src/index.ts");
-    assert.equal(actual?.text, "src/index.ts at release/1.1 in olivierdagenais/tampermonkey-copy-url")
-})
+    assert.equal(
+        actual?.destination,
+        "https://github.com/olivierdagenais/tampermonkey-copy-url/blob/release/1.1/src/index.ts"
+    );
+    assert.equal(
+        actual?.text,
+        "src/index.ts at release/1.1 in olivierdagenais/tampermonkey-copy-url"
+    );
+});

--- a/src/parsers/GitHub.ts
+++ b/src/parsers/GitHub.ts
@@ -4,37 +4,44 @@ import { Parser } from "../Parser";
 export class GitHub implements Parser {
     parseLink(doc: Document, url: string): Link | null {
         if (url.startsWith("https://github.com/")) {
-            const titleElement : HTMLElement | null = doc.querySelector("html head title");
+            const titleElement: HTMLElement | null =
+                doc.querySelector("html head title");
             // TODO: implement special handling for PRs, issues, source code
             if (titleElement) {
                 var titleString = titleElement.textContent ?? url;
-                const blobUrlRegex = /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/blob\/(?<refSpecAndPath>.+)/;
+                const blobUrlRegex =
+                    /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/blob\/(?<refSpecAndPath>.+)/;
                 const blobUrlMatch = url.match(blobUrlRegex);
                 if (blobUrlMatch && blobUrlMatch.groups) {
                     const blobUrlGroups = blobUrlMatch.groups;
                     const refSpecAndPath = blobUrlGroups.refSpecAndPath;
-                    const blobTitleRegex = /[^/]+\/(?<fileName>.+) at (?<refSpec>.+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
+                    const blobTitleRegex =
+                        /[^/]+\/(?<fileName>.+) at (?<refSpec>.+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
                     const blobTitleMatch = titleString.match(blobTitleRegex);
                     if (blobTitleMatch && blobTitleMatch.groups) {
                         const blobTitleGroups = blobTitleMatch.groups;
                         const refSpec = blobTitleGroups.refSpec;
-                        const path = refSpecAndPath.substring(refSpec.length + 1 /* the slash */);
+                        const path = refSpecAndPath.substring(
+                            refSpec.length + 1 /* the slash */
+                        );
                         titleString = `${path} at ${refSpec} in ${blobUrlGroups.userOrOrg}/${blobUrlGroups.repo}`;
                     }
-                }
-                else {
-                    const numberedUrlRegex = /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/(?:.+)\/(?<id>\d+)/;
+                } else {
+                    const numberedUrlRegex =
+                        /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/(?:.+)\/(?<id>\d+)/;
                     const numberedUrlMatch = url.match(numberedUrlRegex);
                     if (numberedUrlMatch) {
-                        const numberedTitleRegex = /(?<title>.+) · (?:.+) #(?<id>\d+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
-                        const numberedTitleMatch = titleString.match(numberedTitleRegex);
+                        const numberedTitleRegex =
+                            /(?<title>.+) · (?:.+) #(?<id>\d+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
+                        const numberedTitleMatch =
+                            titleString.match(numberedTitleRegex);
                         if (numberedTitleMatch && numberedTitleMatch.groups) {
                             const groups = numberedTitleMatch.groups;
                             titleString = `${groups.userOrOrg}/${groups.repo}#${groups.id}: ${groups.title}`;
                         }
                     }
                 }
-                const result : Link = {
+                const result: Link = {
                     text: titleString,
                     destination: url,
                 };

--- a/src/renderers/Html.spec.ts
+++ b/src/renderers/Html.spec.ts
@@ -3,15 +3,15 @@ import { Clipboard } from "../Clipboard";
 import { Link } from "../Link";
 import { Html } from "./Html";
 
-test('should render a simple link', () => {
-    const cut : Html = new Html();
-    const link : Link = {
+test("should render a simple link", () => {
+    const cut: Html = new Html();
+    const link: Link = {
         text: "example",
         destination: "https://www.example.com",
     };
 
-    const actual : Clipboard = cut.render(link);
+    const actual: Clipboard = cut.render(link);
 
-    assert.equal(actual.text, 'example');
+    assert.equal(actual.text, "example");
     assert.equal(actual.html, '<a href="https://www.example.com">example</a>');
-})
+});

--- a/src/renderers/Html.ts
+++ b/src/renderers/Html.ts
@@ -4,7 +4,7 @@ import { Renderer } from "../Renderer";
 
 export class Html implements Renderer {
     render(link: Link): Clipboard {
-        let result : Clipboard = {
+        let result: Clipboard = {
             text: link.text,
             html: `<a href="${link.destination}">${link.text}</a>`,
         };

--- a/src/renderers/Markdown.spec.ts
+++ b/src/renderers/Markdown.spec.ts
@@ -3,14 +3,14 @@ import { Clipboard } from "../Clipboard";
 import { Link } from "../Link";
 import { Markdown } from "./Markdown";
 
-test('should render a simple link', () => {
-    const cut : Markdown = new Markdown();
-    const link : Link = {
+test("should render a simple link", () => {
+    const cut: Markdown = new Markdown();
+    const link: Link = {
         text: "example",
         destination: "https://www.example.com",
     };
 
-    const actual : Clipboard = cut.render(link);
+    const actual: Clipboard = cut.render(link);
 
     assert.equal(actual.text, "[example](https://www.example.com)");
-})
+});

--- a/src/renderers/Markdown.ts
+++ b/src/renderers/Markdown.ts
@@ -4,7 +4,7 @@ import { Renderer } from "../Renderer";
 
 export class Markdown implements Renderer {
     render(link: Link): Clipboard {
-        let result : Clipboard = {
+        let result: Clipboard = {
             text: `[${link.text}](${link.destination})`,
             html: null,
         };

--- a/src/renderers/Textile.spec.ts
+++ b/src/renderers/Textile.spec.ts
@@ -3,14 +3,14 @@ import { Clipboard } from "../Clipboard";
 import { Link } from "../Link";
 import { Textile } from "./Textile";
 
-test('should render a simple link', () => {
-    const cut : Textile = new Textile();
-    const link : Link = {
+test("should render a simple link", () => {
+    const cut: Textile = new Textile();
+    const link: Link = {
         text: "example",
         destination: "https://www.example.com",
     };
 
-    const actual : Clipboard = cut.render(link);
+    const actual: Clipboard = cut.render(link);
 
-    assert.equal(actual.text, '[example|https://www.example.com]');
-})
+    assert.equal(actual.text, "[example|https://www.example.com]");
+});

--- a/src/renderers/Textile.ts
+++ b/src/renderers/Textile.ts
@@ -4,7 +4,7 @@ import { Renderer } from "../Renderer";
 
 export class Textile implements Renderer {
     render(link: Link): Clipboard {
-        let result : Clipboard = {
+        let result: Clipboard = {
             text: `[${link.text}|${link.destination}]`,
             html: null,
         };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,101 +1,101 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-    /* Projects */
-    // "incremental": true,                              /* Enable incremental compilation */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+        /* Projects */
+        // "incremental": true,                              /* Enable incremental compilation */
+        // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+        // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+        // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+        // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+        // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
-    /* Language and Environment */
-    "target": "ES6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
-    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+        /* Language and Environment */
+        "target": "ES6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+        // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+        // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+        // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+        // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+        // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+        // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+        // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+        // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    "resolveJsonModule": true,                           /* Enable importing .json files */
-    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+        /* Modules */
+        "module": "commonjs" /* Specify what module code is generated. */,
+        // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+        // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+        // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+        // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+        // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+        // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+        // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+        // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+        "resolveJsonModule": true /* Enable importing .json files */,
+        // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
 
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+        /* JavaScript Support */
+        // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+        // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+        // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+        /* Emit */
+        // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+        // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+        // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+        // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+        // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+        // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+        // "removeComments": true,                           /* Disable emitting comments. */
+        // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+        // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+        // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+        // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+        // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+        // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+        // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+        // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+        // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+        // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+        // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+        // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+        // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+        // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+        // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+        /* Interop Constraints */
+        // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+        // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+        "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+        // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+        "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+        /* Type Checking */
+        "strict": true /* Enable all strict type-checking options. */,
+        // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+        // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+        // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+        // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+        // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+        // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+        // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+        // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+        // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+        // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+        // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+        // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+        // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+        // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+        // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+        // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+        // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+        // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+        /* Completeness */
+        // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,7 +3,7 @@ import { Configuration, BannerPlugin } from "webpack";
 import { generateHeader } from "./plugins/userscript.plugin";
 
 const config: Configuration = {
-    mode: 'none',
+    mode: "none",
     entry: "./src/index.ts",
     output: {
         path: path.resolve(__dirname, "userscript"),
@@ -27,8 +27,8 @@ const config: Configuration = {
             banner: generateHeader(),
             raw: true,
             entryOnly: true,
-        })
-    ]
+        }),
+    ],
 };
 
 export default config;


### PR DESCRIPTION
It turns out I have [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for Visual Studio Code installed and it works much better if:
1. There's a `.prettierrc` file in the root of the repository.
1. It's configured to format on save.