### PR TITLE
feat: add support for Bitbucket

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 // Keep this list sorted!
+import { Bitbucket } from "./parsers/Bitbucket";
 import { Clipboard } from "./Clipboard";
 import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
@@ -14,6 +15,7 @@ const renderers: Renderer[] = [new Html(), new Markdown(), new Textile()];
 // parsers will be attempted in the order defined here
 const parsers: Parser[] = [
     new GitHub(),
+    new Bitbucket(),
     // always keep this one LAST in this list!
     new Default(),
 ];

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -203,7 +203,12 @@ test("should parse a link to a file and make it a specific commit", () => {
                                                 >
                                                     48e30865eb4
                                                 </a>
-                                                <time datetime="2022-05-11T16:22:58-0400" title="11 May 2022 04:22 PM">11 May 2022</time>
+                                                <time
+                                                    datetime="2022-05-11T16:22:58-0400"
+                                                    title="11 May 2022 04:22 PM"
+                                                >
+                                                    11 May 2022
+                                                </time>
                                             </span>
                                         </div>
                                     </div>

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -166,6 +166,73 @@ test("should parse a link to a file at a specific commit", () => {
     );
 });
 
+test("should parse a link to a file and make it a specific commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>Source of github.py - jf_agent - Stash</title>
+    </head>
+    <body>
+        <section id="content" role="main">
+            <div class="aui-page-panel content-body" id="aui-page-panel-content-body">
+                <div class="aui-page-panel-inner">
+                    <section class="aui-page-panel-content">
+                        <div class="aui-toolbar2 branch-selector-toolbar" role="toolbar">
+                            <div class="aui-toolbar2-inner">
+                                <div class="aui-toolbar2-secondary commit-badge-container">
+                                    <div class="commit-badge-oneline">
+                                        <div class="double-avatar-with-name avatar-with-name">
+                                            <span class="commit-details">
+                                                <a
+                                                    href="/users/odagenais"
+                                                    class="commit-author"
+                                                    title="Olivier Dagenais"
+                                                >
+                                                    Olivier Dagenais
+                                                </a>
+                                                authored and
+                                                <span class="commit-author" title="Matt Klein">
+                                                    Matt Klein
+                                                </span>
+                                                committed
+                                                <a
+                                                    class="commitid"
+                                                    href="/projects/TP/repos/jf_agent/commits/48e30865eb4e894443fd554db2f86eac0807f8a0#jf_agent/git/github.py"
+                                                    data-commit-message="fix: sanitize GitHub PR comment bodies"
+                                                    data-commitid="48e30865eb4e894443fd554db2f86eac0807f8a0"
+                                                >
+                                                    48e30865eb4
+                                                </a>
+                                                <time datetime="2022-05-11T16:22:58-0400" title="11 May 2022 04:22 PM">11 May 2022</time>
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </section>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py#377,379-381,383"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=48e30865eb4e894443fd554db2f86eac0807f8a0#377,379-381,383"
+    );
+    assert.equal(
+        actual?.text,
+        "lines 377,379-381,383 of jf_agent/git/github.py at commit 48e30865eb in TP/jf_agent"
+    );
+});
+
 test("should parse a link to a line in a file at a specific commit", () => {
     const html = `
 <html>

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -36,3 +36,27 @@ test("should parse a simple Bitbucket pull request page", () => {
         "TP/jf_agent#4: DO-8731: fix: sanitize GitHub PR comment bodies"
     );
 });
+
+test("should parse a deep link to a line in a file in a PR's commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>Pull Request #4: DO-8731: fix: sanitize GitHub PR comment bodies - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/pull-requests/4/commits/69336ecfefe0dec16963b9d2247b7ce5617939d0#jf_agent/git/github.py?f=379"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/pull-requests/4/commits/69336ecfefe0dec16963b9d2247b7ce5617939d0#jf_agent/git/github.py?f=379"
+    );
+    assert.equal(
+        actual?.text,
+        "line 379 of jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent#4: DO-8731: fix: sanitize GitHub PR comment bodies"
+    );
+});

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -132,3 +132,27 @@ test("should parse a link to a list of commits for a ref", () => {
     );
     assert.equal(actual?.text, "commits at refs/heads/master in TP/jf_agent");
 });
+
+test("should parse a link to lines in a file at a specific commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>Source of github.py - jf_agent - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0#377,379-381,383"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0#377,379-381,383"
+    );
+    assert.equal(
+        actual?.text,
+        "lines 377,379-381,383 of jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent"
+    );
+});

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -60,3 +60,27 @@ test("should parse a deep link to a line in a file in a PR's commit", () => {
         "line 379 of jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent#4: DO-8731: fix: sanitize GitHub PR comment bodies"
     );
 });
+
+test("should parse a deep link to a file in a commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>ThirdParty / jf_agent / 69336ecfefe - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/commits/69336ecfefe0dec16963b9d2247b7ce5617939d0#jf_agent/git/github.py"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/commits/69336ecfefe0dec16963b9d2247b7ce5617939d0#jf_agent/git/github.py"
+    );
+    assert.equal(
+        actual?.text,
+        "jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent"
+    );
+});

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -84,3 +84,24 @@ test("should parse a deep link to a file in a commit", () => {
         "jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent"
     );
 });
+
+test("should parse a link to a list of commits for a ref", () => {
+    const html = `
+<html>
+    <head>
+        <title>ThirdParty / jf_agent - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/commits?until=refs%2Fheads%2Fmaster&merges=include"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/commits?until=refs%2Fheads%2Fmaster&merges=include"
+    );
+    assert.equal(actual?.text, "commits at refs/heads/master in TP/jf_agent");
+});

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -13,5 +13,26 @@ function testParseLink(html: string, url: string): Link | null {
     return actual;
 }
 
-test("TODO", () => {
+test("should parse a simple Bitbucket pull request page", () => {
+    const html = `
+<html>
+    <head>
+        <title>Pull Request #4: DO-8731: fix: sanitize GitHub PR comment bodies - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/pull-requests/4/overview"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/pull-requests/4/overview"
+    );
+    assert.equal(
+        actual?.text,
+        "TP/jf_agent#4: DO-8731: fix: sanitize GitHub PR comment bodies"
+    );
 });

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -1,0 +1,17 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { Bitbucket } from "./Bitbucket";
+
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Bitbucket();
+
+    const actual: Link | null = cut.parseLink(document, url);
+    return actual;
+}
+
+test("TODO", () => {
+});

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -133,6 +133,54 @@ test("should parse a link to a list of commits for a ref", () => {
     assert.equal(actual?.text, "commits at refs/heads/master in TP/jf_agent");
 });
 
+test("should parse a link to a file at a specific commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>Source of github.py - jf_agent - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0"
+    );
+    assert.equal(
+        actual?.text,
+        "jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent"
+    );
+});
+
+test("should parse a link to a line in a file at a specific commit", () => {
+    const html = `
+<html>
+    <head>
+        <title>Source of github.py - jf_agent - Stash</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0#379"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=69336ecfefe0dec16963b9d2247b7ce5617939d0#379"
+    );
+    assert.equal(
+        actual?.text,
+        "line 379 of jf_agent/git/github.py at commit 69336ecfef in TP/jf_agent"
+    );
+});
+
 test("should parse a link to lines in a file at a specific commit", () => {
     const html = `
 <html>

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -238,6 +238,119 @@ test("should parse a link to a file and make it a specific commit", () => {
     );
 });
 
+test("fuller/heavier sample, link to a file and make it a specific commit", () => {
+    const html = `
+<html>
+<head>
+    <title>
+        <title>Source of github.py - jf_agent - Stash</title>
+    </title>
+</head>
+<body class="aui-page-sidebar bitbucket-theme scrolling-forwarded">
+    <ul id="assistive-skip-links" class="assistive">
+    </ul>
+    <div id="page" style="">
+        <!-- start #header -->
+        <header id="header" role="banner">
+            <section class="notifications"></section>
+            <nav class="aui-header aui-dropdown2-trigger-group" role="navigation" resolved=""
+                data-aui-responsive="true">
+                <div class="aui-header-inner">
+                </div> <!-- End .aui-header-inner -->
+            </nav> <!-- End .aui-header -->
+        </header><!-- End #header -->
+        <!-- Start #content -->
+        <section id="content" role="main" data-reposlug="jf_agent" data-projectkey="TP">
+            <section class="notifications"></section>
+            <div id="aui-sidebar-content" class="aui-sidebar" tabindex="-1" aria-expanded="true">
+            </div>
+            <div class="aui-page-panel content-body" id="aui-page-panel-content-body" tabindex="-1">
+                <div class="aui-page-panel-inner">
+                    <section class="aui-page-panel-content">
+                        <div id="default-reviewers-feature-discovery-meta"></div>
+                        <header class="aui-page-header page-header-flex">
+                            <div class="aui-page-header-inner">
+                            </div><!-- .aui-page-header-inner -->
+                        </header><!-- .aui-page-header -->
+                        <div class="aui-toolbar2 branch-selector-toolbar" role="toolbar">
+                            <div class="aui-toolbar2-inner">
+                                <div class="aui-toolbar2-primary"></div>
+                                <div class="aui-toolbar2-secondary commit-badge-container">
+                                    <div class="commit-badge-oneline">
+                                        <div class="double-avatar-with-name avatar-with-name">
+                                            <span
+                                                class="aui-avatar aui-avatar-small user-avatar first-person"
+                                                data-username="odagenais">
+                                                <span class="aui-avatar-inner">
+                                                    <img src="/users/odagenais/avatar.png?s=48&amp;v=1625588370249"
+                                                        alt="Olivier Dagenais">
+                                                </span>
+                                            </span>
+                                            <span
+                                                class="aui-avatar aui-avatar-small user-avatar second-person"
+                                                data-username="Matt Klein">
+                                                <span class="aui-avatar-inner">
+                                                    <img src="https://secure.gravatar.com/avatar/bfa79aef93f4a085f9646c97c847be58.jpg?s=48&amp;d=mm"
+                                                        alt="Matt Klein">
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <span class="commit-details">
+                                            <a href="/users/odagenais" class="commit-author"
+                                                title="Olivier Dagenais">
+                                                Olivier Dagenais
+                                            </a>
+                                            authored and
+                                            <span class="commit-author" title="Matt Klein">
+                                                Matt Klein
+                                            </span>
+                                            committed
+                                            <a class="commitid"
+                                                href="/projects/TP/repos/jf_agent/commits/48e30865eb4e894443fd554db2f86eac0807f8a0#jf_agent/git/github.py"
+                                                data-commit-message="fix: sanitize GitHub PR comment bodies"
+                                                data-commitid="48e30865eb4e894443fd554db2f86eac0807f8a0"
+                                                data-inited="true">
+                                                48e30865eb4
+                                            </a>
+                                            <time datetime="2022-05-11T16:22:58-0400"
+                                                title="11 May 2022 04:22 PM">
+                                                11 May 2022
+                                            </time>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section><!-- .aui-page-panel-content -->
+                </div><!-- .aui-page-panel-inner -->
+            </div><!-- .aui-page-panel -->
+        </section><!-- End #content -->
+        <!-- Start #footer -->
+        <footer id="footer" role="contentinfo" style="display: none;">
+            <section class="notifications"></section>
+            <section class="footer-body">
+            </section>
+        </footer><!-- End #footer -->
+    </div>
+</body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py#377,379-381,383"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/jf_agent/git/github.py?at=48e30865eb4e894443fd554db2f86eac0807f8a0#377,379-381,383"
+    );
+    assert.equal(
+        actual?.text,
+        "lines 377,379-381,383 of jf_agent/git/github.py at commit 48e30865eb in TP/jf_agent"
+    );
+});
+
 test("should parse a link to a line in a file at a specific commit", () => {
     const html = `
 <html>

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -13,6 +13,15 @@ function testParseLink(html: string, url: string): Link | null {
     return actual;
 }
 
+test("getPrettyRef with a commit ID as a string", () => {
+    const input = "69336ecfefe0dec16963b9d2247b7ce5617939d0";
+    const cut = new Bitbucket();
+
+    const actual = cut.getPrettyRef(input);
+
+    assert.equal(actual, "69336ecfef");
+});
+
 test("getPrettyRef with a commit ID", () => {
     const input = { ref: "69336ecfefe0dec16963b9d2247b7ce5617939d0" };
     const cut = new Bitbucket();

--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -13,6 +13,33 @@ function testParseLink(html: string, url: string): Link | null {
     return actual;
 }
 
+test("getPrettyRef with a commit ID", () => {
+    const input = { ref: "69336ecfefe0dec16963b9d2247b7ce5617939d0" };
+    const cut = new Bitbucket();
+
+    const actual = cut.getPrettyRef(input);
+
+    assert.equal(actual, "69336ecfef");
+});
+
+test("getPrettyRef with an encoded ref", () => {
+    const input = { ref: "refs%2Fheads%2Fmaster" };
+    const cut = new Bitbucket();
+
+    const actual = cut.getPrettyRef(input);
+
+    assert.equal(actual, "refs/heads/master");
+});
+
+test("getPrettyRef with a simple tag", () => {
+    const input = { ref: "v0.0.22" };
+    const cut = new Bitbucket();
+
+    const actual = cut.getPrettyRef(input);
+
+    assert.equal(actual, "v0.0.22");
+});
+
 test("should parse a simple Bitbucket pull request page", () => {
     const html = `
 <html>

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -2,9 +2,11 @@ import { Link } from "../Link";
 import { Parser } from "../Parser";
 
 const prUrlRegex =
-    /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+).*/;
+    /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+)(\/(?<extra>.*))?/;
 
 const prTitleRegex = /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
+const prExtraRegex =
+    /commits\/(?<commitId>[a-f0-9]+)(#(?<path>[^?]+)(\?f=(?<lineNumber>\d+))?)?/;
 
 export class Bitbucket implements Parser {
     parseLink(doc: Document, url: string): Link | null {
@@ -16,6 +18,7 @@ export class Bitbucket implements Parser {
         const project = prUrlGroups.project;
         const repo = prUrlGroups.repo;
         const prId = prUrlGroups.prId;
+        const extra = prUrlGroups.extra;
 
         const titleElement: HTMLElement | null =
             doc.querySelector("html head title");
@@ -29,8 +32,23 @@ export class Bitbucket implements Parser {
         }
         const prTitleGroups = prTitleMatch.groups;
         const summary = prTitleGroups.summary;
+        var prefix = "";
+        if (extra) {
+            const prExtraMatch = extra.match(prExtraRegex);
+            if (prExtraMatch && prExtraMatch.groups) {
+                const prExtraGroups = prExtraMatch.groups;
+                if (prExtraGroups.lineNumber) {
+                    prefix += `line ${prExtraGroups.lineNumber} of `;
+                }
+                if (prExtraGroups.path) {
+                    prefix += `${prExtraGroups.path} at `;
+                }
+                const commitId = prExtraGroups.commitId.substring(0, 10);
+                prefix += `commit ${commitId} in `
+            }
+        }
 
-        const linkText = `${project}/${repo}#${prId}: ${summary}`;
+        const linkText = `${prefix}${project}/${repo}#${prId}: ${summary}`;
         const result: Link = {
             text: linkText,
             destination: url,

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -1,6 +1,8 @@
 import { Link } from "../Link";
 import { Parser } from "../Parser";
 
+const commitUrlRegex =
+    /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/commits\/(?<commitId>[a-f0-9]+)(#(?<path>[^?]+))?/;
 const prUrlRegex =
     /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+)(\/(?<extra>.*))?/;
 
@@ -14,6 +16,24 @@ export class Bitbucket implements Parser {
         if (prUrlMatch && prUrlMatch.groups) {
             const prUrlGroups = prUrlMatch.groups;
             return this.parsePullRequest(doc, url, prUrlGroups);
+        }
+        const commitUrlMatch = url.match(commitUrlRegex);
+        if (commitUrlMatch && commitUrlMatch.groups) {
+            const commitUrlGroups = commitUrlMatch.groups;
+            const project = commitUrlGroups.project;
+            const repo = commitUrlGroups.repo;
+            const commitId = commitUrlGroups.commitId.substring(0, 10);
+            const path = commitUrlGroups.path;
+            var prefix = "";
+            if (path) {
+                prefix += `${path} at `;
+            }
+            const linkText = `${prefix}commit ${commitId} in ${project}/${repo}`;
+            const result: Link = {
+                text: linkText,
+                destination: url,
+            };
+            return result;
         }
         return null;
     }

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -22,7 +22,7 @@ export class Bitbucket implements Parser {
             const commitUrlGroups = commitUrlMatch.groups;
             const project = commitUrlGroups.project;
             const repo = commitUrlGroups.repo;
-            const commitId = commitUrlGroups.commitId.substring(0, 10);
+            const commitId = this.getCommitId(commitUrlGroups);
             const path = commitUrlGroups.path;
             var prefix = "";
             if (path) {
@@ -36,6 +36,10 @@ export class Bitbucket implements Parser {
             return result;
         }
         return null;
+    }
+
+    private getCommitId(matchGroups: { [key: string]: string }): string {
+        return matchGroups.commitId.substring(0, 10);
     }
 
     private parsePullRequest(
@@ -71,7 +75,7 @@ export class Bitbucket implements Parser {
                 if (prExtraGroups.path) {
                     prefix += `${prExtraGroups.path} at `;
                 }
-                const commitId = prExtraGroups.commitId.substring(0, 10);
+                const commitId = this.getCommitId(prExtraGroups);
                 prefix += `commit ${commitId} in `;
             }
         }

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -1,0 +1,8 @@
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+
+export class Bitbucket implements Parser {
+    parseLink(doc: Document, url: string): Link | null {
+        return null;
+    }
+}

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -1,10 +1,13 @@
 import { Link } from "../Link";
 import { Parser } from "../Parser";
 
+const prUrlRegex =
+    /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+).*/;
+
+const prTitleRegex = /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
+
 export class Bitbucket implements Parser {
     parseLink(doc: Document, url: string): Link | null {
-        const prUrlRegex =
-            /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+).*/;
         const prUrlMatch = url.match(prUrlRegex);
         if (!prUrlMatch || !prUrlMatch.groups) {
             return null;
@@ -20,8 +23,6 @@ export class Bitbucket implements Parser {
             return null;
         }
         const titleString = titleElement.textContent;
-        const prTitleRegex =
-            /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
         const prTitleMatch = titleString?.match(prTitleRegex);
         if (!prTitleMatch || !prTitleMatch.groups) {
             return null;

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -109,7 +109,7 @@ export class Bitbucket implements Parser {
             prefix += `commit ${ref} in `;
         } else {
             const anchorElement = doc.querySelector(
-                "html > body > section#content a[data-commitid]"
+                "html > body section#content a[data-commitid]"
             );
             if (anchorElement) {
                 const rawRef = anchorElement.getAttribute("data-commitid");

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -3,7 +3,7 @@ import { Parser } from "../Parser";
 
 const bbUrlRegex =
     /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/(?<rest>.+)/;
-const commitUrlRegex = /commits\/(?<commitId>[a-f0-9]+)(#(?<path>[^?]+))?/;
+const deepCommitUrlRegex = /commits\/(?<commitId>[a-f0-9]+)(#(?<path>[^?]+))?/;
 const prUrlRegex = /pull-requests\/(?<prId>\d+)(\/(?<extra>.*))?/;
 
 const prTitleRegex = /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
@@ -25,11 +25,11 @@ export class Bitbucket implements Parser {
             const prUrlGroups = prUrlMatch.groups;
             return this.parsePullRequest(doc, url, project, repo, prUrlGroups);
         }
-        const commitUrlMatch = rest.match(commitUrlRegex);
-        if (commitUrlMatch && commitUrlMatch.groups) {
-            const commitUrlGroups = commitUrlMatch.groups;
-            const commitId = this.getCommitId(commitUrlGroups);
-            const path = commitUrlGroups.path;
+        const deepCommitUrlMatch = rest.match(deepCommitUrlRegex);
+        if (deepCommitUrlMatch && deepCommitUrlMatch.groups) {
+            const deepCommitUrlGroups = deepCommitUrlMatch.groups;
+            const commitId = this.getCommitId(deepCommitUrlGroups);
+            const path = deepCommitUrlGroups.path;
             var prefix = "";
             if (path) {
                 prefix += `${path} at `;

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -3,6 +3,37 @@ import { Parser } from "../Parser";
 
 export class Bitbucket implements Parser {
     parseLink(doc: Document, url: string): Link | null {
-        return null;
+        const prUrlRegex =
+            /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/pull-requests\/(?<prId>\d+).*/;
+        const prUrlMatch = url.match(prUrlRegex);
+        if (!prUrlMatch || !prUrlMatch.groups) {
+            return null;
+        }
+        const prUrlGroups = prUrlMatch.groups;
+        const project = prUrlGroups.project;
+        const repo = prUrlGroups.repo;
+        const prId = prUrlGroups.prId;
+
+        const titleElement: HTMLElement | null =
+            doc.querySelector("html head title");
+        if (!titleElement) {
+            return null;
+        }
+        const titleString = titleElement.textContent;
+        const prTitleRegex =
+            /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
+        const prTitleMatch = titleString?.match(prTitleRegex);
+        if (!prTitleMatch || !prTitleMatch.groups) {
+            return null;
+        }
+        const prTitleGroups = prTitleMatch.groups;
+        const summary = prTitleGroups.summary;
+
+        const linkText = `${project}/${repo}#${prId}: ${summary}`;
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
     }
 }

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -57,8 +57,13 @@ export class Bitbucket implements Parser {
         return null;
     }
 
-    getPrettyRef(matchGroups: { [key: string]: string }): string {
-        const ref = matchGroups.ref;
+    getPrettyRef(
+        stringOrMatchGroups: string | { [key: string]: string }
+    ): string {
+        const ref: string =
+            typeof stringOrMatchGroups === "string"
+                ? stringOrMatchGroups
+                : stringOrMatchGroups.ref;
         if (ref.indexOf("%") > -1) {
             return decodeURIComponent(ref);
         }

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -11,10 +11,18 @@ const prExtraRegex =
 export class Bitbucket implements Parser {
     parseLink(doc: Document, url: string): Link | null {
         const prUrlMatch = url.match(prUrlRegex);
-        if (!prUrlMatch || !prUrlMatch.groups) {
-            return null;
+        if (prUrlMatch && prUrlMatch.groups) {
+            const prUrlGroups = prUrlMatch.groups;
+            return this.parsePullRequest(doc, url, prUrlGroups);
         }
-        const prUrlGroups = prUrlMatch.groups;
+        return null;
+    }
+
+    private parsePullRequest(
+        doc: Document,
+        url: string,
+        prUrlGroups: { [key: string]: string }
+    ): Link | null {
         const project = prUrlGroups.project;
         const repo = prUrlGroups.repo;
         const prId = prUrlGroups.prId;
@@ -44,7 +52,7 @@ export class Bitbucket implements Parser {
                     prefix += `${prExtraGroups.path} at `;
                 }
                 const commitId = prExtraGroups.commitId.substring(0, 10);
-                prefix += `commit ${commitId} in `
+                prefix += `commit ${commitId} in `;
             }
         }
 

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -28,24 +28,38 @@ export class Bitbucket implements Parser {
         const deepCommitUrlMatch = rest.match(deepCommitUrlRegex);
         if (deepCommitUrlMatch && deepCommitUrlMatch.groups) {
             const deepCommitUrlGroups = deepCommitUrlMatch.groups;
-            const commitId = this.getCommitId(deepCommitUrlGroups);
-            const path = deepCommitUrlGroups.path;
-            var prefix = "";
-            if (path) {
-                prefix += `${path} at `;
-            }
-            const linkText = `${prefix}commit ${commitId} in ${project}/${repo}`;
-            const result: Link = {
-                text: linkText,
-                destination: url,
-            };
-            return result;
+            return this.parseDeepCommit(
+                url,
+                project,
+                repo,
+                deepCommitUrlGroups
+            );
         }
         return null;
     }
 
     private getCommitId(matchGroups: { [key: string]: string }): string {
         return matchGroups.commitId.substring(0, 10);
+    }
+
+    private parseDeepCommit(
+        url: string,
+        project: string,
+        repo: string,
+        deepCommitUrlGroups: { [key: string]: string }
+    ) {
+        const commitId = this.getCommitId(deepCommitUrlGroups);
+        const path = deepCommitUrlGroups.path;
+        var prefix = "";
+        if (path) {
+            prefix += `${path} at `;
+        }
+        const linkText = `${prefix}commit ${commitId} in ${project}/${repo}`;
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
     }
 
     private parsePullRequest(


### PR DESCRIPTION
I tried it on our server and, after a fix to the DOM selector for the `/browse` URL in "auto-magic" mode, I got something like this:

```markdown
[Dockerfile at commit 65e88811ff in TP/jf_agent](https://bitbucket.example.com/projects/TP/repos/jf_agent/browse/Dockerfile?at=65e88811ff95f9b9757fd44e04e9f8e5dd8f1a11)
```

Mission accomplished!