### PR TITLE
feat: add support for Jira issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Clipboard } from "./Clipboard";
 import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
 import { Html } from "./renderers/Html";
+import { Jira } from "./parsers/Jira";
 import { Link } from "./Link";
 import { Markdown } from "./renderers/Markdown";
 import { Renderer } from "./Renderer";
@@ -16,6 +17,7 @@ const renderers: Renderer[] = [new Html(), new Markdown(), new Textile()];
 const parsers: Parser[] = [
     new GitHub(),
     new Bitbucket(),
+    new Jira(),
     // always keep this one LAST in this list!
     new Default(),
 ];

--- a/src/parsers/AbstractParser.ts
+++ b/src/parsers/AbstractParser.ts
@@ -1,0 +1,15 @@
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+
+export abstract class AbstractParser implements Parser {
+    abstract parseLink(doc: Document, url: string): Link | null;
+
+    findTitle(doc: Document): string | null {
+        const titleElement: HTMLElement | null =
+            doc.querySelector("html head title");
+        if (!titleElement) {
+            return null;
+        }
+        return titleElement.textContent;
+    }
+}

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -1,5 +1,5 @@
+import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
-import { Parser } from "../Parser";
 
 const bbUrlRegex =
     /https:\/\/(?<host>[^/]+)\/projects\/(?<project>[^/]+)\/repos\/(?<repo>[^/]+)\/(?<rest>.+)/;
@@ -13,7 +13,7 @@ const prTitleRegex = /Pull Request #(?<prId>\d+): (?<summary>.+) - Stash/;
 const prExtraRegex =
     /commits\/(?<ref>[^#]+)(#(?<path>[^?]+)(\?f=(?<lineNumber>\d+))?)?/;
 
-export class Bitbucket implements Parser {
+export class Bitbucket extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const bbUrlMatch = url.match(bbUrlRegex);
         if (!bbUrlMatch || !bbUrlMatch.groups) {
@@ -177,12 +177,7 @@ export class Bitbucket implements Parser {
         const prId = prUrlGroups.prId;
         const extra = prUrlGroups.extra;
 
-        const titleElement: HTMLElement | null =
-            doc.querySelector("html head title");
-        if (!titleElement) {
-            return null;
-        }
-        const titleString = titleElement.textContent;
+        const titleString = this.findTitle(doc);
         const prTitleMatch = titleString?.match(prTitleRegex);
         if (!prTitleMatch || !prTitleMatch.groups) {
             return null;

--- a/src/parsers/GitHub.ts
+++ b/src/parsers/GitHub.ts
@@ -1,52 +1,49 @@
+import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
-import { Parser } from "../Parser";
 
-export class GitHub implements Parser {
+export class GitHub extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         if (url.startsWith("https://github.com/")) {
-            const titleElement: HTMLElement | null =
-                doc.querySelector("html head title");
+            const titleContent = this.findTitle(doc);
+            var titleString = titleContent ?? url;
             // TODO: implement special handling for PRs, issues, source code
-            if (titleElement) {
-                var titleString = titleElement.textContent ?? url;
-                const blobUrlRegex =
-                    /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/blob\/(?<refSpecAndPath>.+)/;
-                const blobUrlMatch = url.match(blobUrlRegex);
-                if (blobUrlMatch && blobUrlMatch.groups) {
-                    const blobUrlGroups = blobUrlMatch.groups;
-                    const refSpecAndPath = blobUrlGroups.refSpecAndPath;
-                    const blobTitleRegex =
-                        /[^/]+\/(?<fileName>.+) at (?<refSpec>.+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
-                    const blobTitleMatch = titleString.match(blobTitleRegex);
-                    if (blobTitleMatch && blobTitleMatch.groups) {
-                        const blobTitleGroups = blobTitleMatch.groups;
-                        const refSpec = blobTitleGroups.refSpec;
-                        const path = refSpecAndPath.substring(
-                            refSpec.length + 1 /* the slash */
-                        );
-                        titleString = `${path} at ${refSpec} in ${blobUrlGroups.userOrOrg}/${blobUrlGroups.repo}`;
-                    }
-                } else {
-                    const numberedUrlRegex =
-                        /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/(?:.+)\/(?<id>\d+)/;
-                    const numberedUrlMatch = url.match(numberedUrlRegex);
-                    if (numberedUrlMatch) {
-                        const numberedTitleRegex =
-                            /(?<title>.+) · (?:.+) #(?<id>\d+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
-                        const numberedTitleMatch =
-                            titleString.match(numberedTitleRegex);
-                        if (numberedTitleMatch && numberedTitleMatch.groups) {
-                            const groups = numberedTitleMatch.groups;
-                            titleString = `${groups.userOrOrg}/${groups.repo}#${groups.id}: ${groups.title}`;
-                        }
+            const blobUrlRegex =
+                /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/blob\/(?<refSpecAndPath>.+)/;
+            const blobUrlMatch = url.match(blobUrlRegex);
+            if (blobUrlMatch && blobUrlMatch.groups) {
+                const blobUrlGroups = blobUrlMatch.groups;
+                const refSpecAndPath = blobUrlGroups.refSpecAndPath;
+                const blobTitleRegex =
+                    /[^/]+\/(?<fileName>.+) at (?<refSpec>.+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
+                const blobTitleMatch = titleString.match(blobTitleRegex);
+                if (blobTitleMatch && blobTitleMatch.groups) {
+                    const blobTitleGroups = blobTitleMatch.groups;
+                    const refSpec = blobTitleGroups.refSpec;
+                    const path = refSpecAndPath.substring(
+                        refSpec.length + 1 /* the slash */
+                    );
+                    titleString = `${path} at ${refSpec} in ${blobUrlGroups.userOrOrg}/${blobUrlGroups.repo}`;
+                }
+            } else {
+                const numberedUrlRegex =
+                    /https:\/\/github.com\/(?<userOrOrg>[^/]+)\/(?<repo>[^/]+)\/(?:.+)\/(?<id>\d+)/;
+                const numberedUrlMatch = url.match(numberedUrlRegex);
+                if (numberedUrlMatch) {
+                    const numberedTitleRegex =
+                        /(?<title>.+) · (?:.+) #(?<id>\d+) · (?<userOrOrg>[^/]+)\/(?<repo>.+)/;
+                    const numberedTitleMatch =
+                        titleString.match(numberedTitleRegex);
+                    if (numberedTitleMatch && numberedTitleMatch.groups) {
+                        const groups = numberedTitleMatch.groups;
+                        titleString = `${groups.userOrOrg}/${groups.repo}#${groups.id}: ${groups.title}`;
                     }
                 }
-                const result: Link = {
-                    text: titleString,
-                    destination: url,
-                };
-                return result;
             }
+            const result: Link = {
+                text: titleString,
+                destination: url,
+            };
+            return result;
         }
         return null;
     }

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -19,6 +19,16 @@ test("should parse a simple issue page", () => {
     <head>
         <title>[DO-8731] GitHub PR comment bodies are fully rendered - Jira</title>
     </head>
+    <body>
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">GitHub PR comment bodies are fully rendered</h1>
+                </div>
+            </div>
+        </div>
+    </body>
 </html>`;
 
     const actual = testParseLink(
@@ -43,6 +53,16 @@ test("should parse a title from a custom JIRA deployment", () => {
     <head>
         <title>[JENKINS-69135] Add a &quot;Versions to include&quot; field to the Global Library Cache feature - Jenkins Jira</title>
     </head>
+    <body>
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">Add a &quot;Versions to include&quot; field to the Global Library Cache feature</h1>
+                </div>
+            </div>
+        </div>
+    </body>
 </html>`;
 
     const actual = testParseLink(
@@ -58,5 +78,42 @@ test("should parse a title from a custom JIRA deployment", () => {
     assert.equal(
         actual?.text,
         "JENKINS-69135: Add a \"Versions to include\" field to the Global Library Cache feature"
+    );
+});
+
+test("should parse a title without the word jira in it", () => {
+    const html = `
+<html>
+    <body
+        id="jira"
+        class="aui-layout aui-theme-default   aui-page-sidebar aui-sidebar-collapsed page-type-split page-issue-navigator page-type-navigator"
+        data-version="8.20.12"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <title>[BSERV-12252] Disable wordwrap in Pull Request diff view - Create and track feature requests for Atlassian products.</title>
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">Disable wordwrap in Pull Request diff view</h1>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://jira.atlassian.com/browse/BSERV-12252"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://jira.atlassian.com/browse/BSERV-12252"
+    );
+    assert.equal(
+        actual?.text,
+        "BSERV-12252: Disable wordwrap in Pull Request diff view"
     );
 });

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -1,0 +1,16 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { Jira } from "./Jira";
+
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Jira();
+
+    const actual: Link | null = cut.parseLink(document, url);
+    return actual;
+}
+
+test("TODO", () => {});

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -36,3 +36,27 @@ test("should parse a simple issue page", () => {
         "DO-8731: GitHub PR comment bodies are fully rendered"
     );
 });
+
+test("should parse a title from a custom JIRA deployment", () => {
+    const html = `
+<html>
+    <head>
+        <title>[JENKINS-69135] Add a &quot;Versions to include&quot; field to the Global Library Cache feature - Jenkins Jira</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://issues.jenkins.io/browse/JENKINS-69135"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://issues.jenkins.io/browse/JENKINS-69135"
+    );
+    assert.equal(
+        actual?.text,
+        "JENKINS-69135: Add a \"Versions to include\" field to the Global Library Cache feature"
+    );
+});

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -13,4 +13,26 @@ function testParseLink(html: string, url: string): Link | null {
     return actual;
 }
 
-test("TODO", () => {});
+test("should parse a simple issue page", () => {
+    const html = `
+<html>
+    <head>
+        <title>[DO-8731] GitHub PR comment bodies are fully rendered - Jira</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://jira.example.com/browse/DO-8731"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://jira.example.com/browse/DO-8731"
+    );
+    assert.equal(
+        actual?.text,
+        "DO-8731: GitHub PR comment bodies are fully rendered"
+    );
+});

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -1,0 +1,8 @@
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+
+export class Jira implements Parser {
+    parseLink(doc: Document, url: string): Link | null {
+        return null;
+    }
+}

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -4,7 +4,7 @@ import { Link } from "../Link";
 const issueUrlRegex =
     /https:\/\/(?<host>[^/]+)\/browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
 const issueTitleRegex =
-    /\[(?<issueKey>[A-Z][A-Z_0-9]+-[0-9]+)\] (?<summary>.+) - Jira/;
+    /\[(?<issueKey>[A-Z][A-Z_0-9]+-[0-9]+)\] (?<summary>.+) - .*Jira/;
 export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const issueUrlMatch = url.match(issueUrlRegex);

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -3,8 +3,6 @@ import { Link } from "../Link";
 
 const issueUrlRegex =
     /https:\/\/(?<host>[^/]+)\/browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
-const issueTitleRegex =
-    /\[(?<issueKey>[A-Z][A-Z_0-9]+-[0-9]+)\] (?<summary>.+) - .*Jira/;
 export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const issueUrlMatch = url.match(issueUrlRegex);
@@ -15,15 +13,11 @@ export class Jira extends AbstractParser {
         const issueKey = issueUrlGroups.issueKey;
         var linkText = `${issueKey}`;
 
-        const titleString = this.findTitle(doc);
-        if (titleString) {
-            const issueTitleMatch = titleString.match(issueTitleRegex);
-            if (issueTitleMatch && issueTitleMatch.groups) {
-                const issueTitleGroups = issueTitleMatch.groups;
-                const summary = issueTitleGroups.summary;
-                if (summary) {
-                    linkText += `: ${summary}`;
-                }
+        const h1Element : HTMLElement | null = doc.querySelector("#summary-val");
+        if (h1Element) {
+            const summary = h1Element.textContent;
+            if (summary) {
+                linkText += `: ${summary}`;
             }
         }
 

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -1,8 +1,36 @@
+import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
-import { Parser } from "../Parser";
 
-export class Jira implements Parser {
+const issueUrlRegex =
+    /https:\/\/(?<host>[^/]+)\/browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
+const issueTitleRegex =
+    /\[(?<issueKey>[A-Z][A-Z_0-9]+-[0-9]+)\] (?<summary>.+) - Jira/;
+export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
-        return null;
+        const issueUrlMatch = url.match(issueUrlRegex);
+        if (!issueUrlMatch || !issueUrlMatch.groups) {
+            return null;
+        }
+        const issueUrlGroups = issueUrlMatch.groups;
+        const issueKey = issueUrlGroups.issueKey;
+        var linkText = `${issueKey}`;
+
+        const titleString = this.findTitle(doc);
+        if (titleString) {
+            const issueTitleMatch = titleString.match(issueTitleRegex);
+            if (issueTitleMatch && issueTitleMatch.groups) {
+                const issueTitleGroups = issueTitleMatch.groups;
+                const summary = issueTitleGroups.summary;
+                if (summary) {
+                    linkText += `: ${summary}`;
+                }
+            }
+        }
+
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
     }
 }


### PR DESCRIPTION

# Manual testing

## Given

I created a special userscript from the output of `npm run build` in a dedicated browser.

## When

I visit https://issues.jenkins.io/browse/JENKINS-69135 and activate the script.

## Then

The following pop-up appears:

![image](https://user-images.githubusercontent.com/297515/212152339-816dad46-f33e-4ab2-b820-8b7f541cabdc.png)

## When

I visit https://jira.atlassian.com/browse/BSERV-12252 and activate the script.

## Then

The following pop-up appears:

![image](https://user-images.githubusercontent.com/297515/212152683-17025062-5392-4e51-888b-53f367f01575.png)

Mission accomplished!