### PR TITLE
Bring Your Own Node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug Current Test File",
+            "autoAttachChildProcesses": true,
+            "skipFiles": [
+                "<node_internals>/**",
+                "**/node_modules/**"
+            ],
+            "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/node/bin/node",
+            "env": {
+                "PATH": "${workspaceRoot}/node_modules/node/bin/"
+            },
+            "args": [
+                "run",
+                "${relativeFile}"
+            ],
+            "smartStep": true,
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@types/tampermonkey": "^4.0.5",
                 "@types/webpack": "^5.28.0",
                 "jsdom": "^19.0.0",
+                "node": "^16.19.0",
                 "package-json-io": "1.0.0",
                 "prettier": "^2.7.1",
                 "ts-loader": "^9.2.6",
@@ -1571,6 +1572,28 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmmirror.com/neo-async/download/neo-async-2.6.2.tgz",
             "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+            "dev": true
+        },
+        "node_modules/node": {
+            "version": "16.19.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-16.19.0.tgz",
+            "integrity": "sha512-gVpwPuk8KZQjNYcuilyEcNLOAm97Q4GNvCrW5pZ9SiQH/shy/G4gInNzITEqF00lb6bjSzmYWCvGlomGkLm3/A==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "node-bin-setup": "^1.0.0"
+            },
+            "bin": {
+                "node": "bin/node"
+            },
+            "engines": {
+                "npm": ">=5.0.0"
+            }
+        },
+        "node_modules/node-bin-setup": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+            "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
             "dev": true
         },
         "node_modules/node-releases": {
@@ -4266,6 +4289,21 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmmirror.com/neo-async/download/neo-async-2.6.2.tgz",
             "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+            "dev": true
+        },
+        "node": {
+            "version": "16.19.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-16.19.0.tgz",
+            "integrity": "sha512-gVpwPuk8KZQjNYcuilyEcNLOAm97Q4GNvCrW5pZ9SiQH/shy/G4gInNzITEqF00lb6bjSzmYWCvGlomGkLm3/A==",
+            "dev": true,
+            "requires": {
+                "node-bin-setup": "^1.0.0"
+            }
+        },
+        "node-bin-setup": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+            "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg==",
             "dev": true
         },
         "node-releases": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@types/tampermonkey": "^4.0.5",
         "@types/webpack": "^5.28.0",
         "jsdom": "^19.0.0",
+        "node": "^16.19.0",
         "package-json-io": "1.0.0",
         "prettier": "^2.7.1",
         "ts-loader": "^9.2.6",


### PR DESCRIPTION
This makes the version of NodeJS we depend on more explicit and then uses it to configure the Debug launch configuration in Visual Studio Code.

I can now set breakpoints and debug tests!