### PR TITLE
feat: initial implementation of ServiceDesk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
 import { Html } from "./renderers/Html";
 import { Jira } from "./parsers/Jira";
+import { ServiceDesk } from "./parsers/ServiceDesk";
 import { Link } from "./Link";
 import { Markdown } from "./renderers/Markdown";
 import { Renderer } from "./Renderer";
@@ -18,6 +19,7 @@ const parsers: Parser[] = [
     new GitHub(),
     new Bitbucket(),
     new Jira(),
+    new ServiceDesk(),
     // always keep this one LAST in this list!
     new Default(),
 ];

--- a/src/parsers/ServiceDesk.spec.ts
+++ b/src/parsers/ServiceDesk.spec.ts
@@ -1,0 +1,47 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { ServiceDesk } from "./ServiceDesk";
+
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new ServiceDesk();
+
+    const actual: Link | null = cut.parseLink(document, url);
+    return actual;
+}
+
+test("should parse a simple request page", () => {
+    const html = `
+<html>
+    <body id="body">
+        <title>ManageEngine ServiceDesk Plus</title>
+        <div id="main">
+            <div id="content">
+                <div id="content-inner">
+                    <!-- etc., etc... -->
+                    <span id="request-id" data-cs-field="req_id" class="mr5 fl">#128701</span>
+                    <span data-cs-field="req_subject" id="req_subject">Configure system A to forward logs to ELK</span>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://servicedesk.example.com/WorkOrder.do?woMode=viewWO&woID=128701"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://servicedesk.example.com/WorkOrder.do?woMode=viewWO&woID=128701"
+    );
+    assert.equal(
+        actual?.text,
+        "ServiceDesk #128701: Configure system A to forward logs to ELK"
+    );
+});

--- a/src/parsers/ServiceDesk.ts
+++ b/src/parsers/ServiceDesk.ts
@@ -1,0 +1,35 @@
+import { AbstractParser } from "./AbstractParser";
+import { Link } from "../Link";
+
+const urlRegex = /https:\/\/(?<host>[^/]+)\/WorkOrder.do\?(?<rest>.+)/
+export class ServiceDesk extends AbstractParser {
+    parseLink(doc: Document, url: string): Link | null {
+        const urlMatch = url.match(urlRegex);
+        if (!urlMatch || !urlMatch.groups) {
+            return null;
+        }
+
+        var linkText = `ServiceDesk`;
+
+        const spanIdElement : HTMLElement | null = doc.querySelector("#request-id");
+        if (spanIdElement) {
+            const requestId = spanIdElement.textContent?.trim();
+            if (requestId) {
+                linkText += ` ${requestId}`;
+            }
+        }
+
+        const spanSubjectElement : HTMLElement | null = doc.querySelector("#req_subject");
+        if (spanSubjectElement) {
+            const requestSubject = spanSubjectElement.textContent?.trim();
+            if (requestSubject) {
+                linkText += `: ${requestSubject}`;
+            }
+        }
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
+    }
+}


### PR DESCRIPTION
# Manual testing

## Given

I created a special userscript from the output of `npm run build` in a dedicated browser.

## When

I visit a ServiceDesk request and activate the script.

## Then

The pop-up appears saying it parsed using "ServiceDesk" and rendered the link as HTML.  I'm able to paste the contents of the clipboard and it looks like I expected it to.

Mission accomplished!