### PR TITLE
feat: add support for Confluence pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // Keep this list sorted!
 import { Bitbucket } from "./parsers/Bitbucket";
 import { Clipboard } from "./Clipboard";
+import { Confluence } from "./parsers/Confluence";
 import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
 import { Html } from "./renderers/Html";
@@ -17,6 +18,7 @@ const renderers: Renderer[] = [new Html(), new Markdown(), new Textile()];
 
 // parsers will be attempted in the order defined here
 const parsers: Parser[] = [
+    new Confluence(),
     new GitHub(),
     new Bitbucket(),
     new Jira(),

--- a/src/parsers/Confluence.spec.ts
+++ b/src/parsers/Confluence.spec.ts
@@ -14,5 +14,40 @@ function testParseLink(html: string, url: string): Link | null {
 }
 
 test("should parse a simple page", () => {
-    // TODO: implement test
+    const html = `
+<html>
+    <head>
+        <title>Supported AWS Objects - Cloudaware Documentation (Public) - Confluence</title>
+        <meta name="ajs-page-title" content="Supported AWS Objects">
+    </head>
+    <body
+        id="com-atlassian-confluence"
+        class="theme-default dashboard aui-layout aui-theme-default"
+    >
+        <div class="PageContent">
+            <!-- etc., etc. -->
+            <h1
+                id="title-text"
+                data-test-id="title-text"
+                data-testid="title-text"
+                style="color: rgb(23, 43, 77);"
+                class="css-1agkp1r e1vqopgf1"
+            >
+                Supported AWS Objects
+            </h1>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://cloudaware.atlassian.net/wiki/spaces/DOCS/pages/3190554625/Supported+AWS+Objects"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://cloudaware.atlassian.net/wiki/spaces/DOCS/pages/3190554625/Supported+AWS+Objects"
+    );
+    assert.equal(actual?.text, "Supported AWS Objects");
 });

--- a/src/parsers/Confluence.spec.ts
+++ b/src/parsers/Confluence.spec.ts
@@ -51,3 +51,43 @@ test("should parse a simple page", () => {
     );
     assert.equal(actual?.text, "Supported AWS Objects");
 });
+
+test("should parse a page about Confluence in Confluence", () => {
+    const html = `
+<html>
+    <head>
+        <title>
+            Create and Edit Pages - Confluence Documentation - Confluence
+        </title>
+        <meta name="ajs-page-title" content="Create and Edit Pages">
+        <meta name="ajs-latest-published-page-title" content="Create and Edit Pages">
+        <meta name="wikilink" content="[CONFDOCS:Create and Edit Pages]">
+    </head>
+    <body
+        id="com-atlassian-confluence"
+        class="theme-default  aui-layout aui-theme-default synchrony-active"
+        data-aui-version="9.2.2"
+    >
+        <div id="page">
+            <!-- etc.. -->
+            <h1 id="title-text" class="with-breadcrumbs">
+                <a href="/confluence/display/CONFDOCS/Create+and+Edit+Pages">
+                    Create and Edit Pages
+                </a>
+            </h1>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages"
+    );
+    assert.equal(actual?.text, "Create and Edit Pages");
+});

--- a/src/parsers/Confluence.spec.ts
+++ b/src/parsers/Confluence.spec.ts
@@ -1,0 +1,18 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { Confluence } from "./Confluence";
+
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Confluence();
+
+    const actual: Link | null = cut.parseLink(document, url);
+    return actual;
+}
+
+test("should parse a simple page", () => {
+    // TODO: implement test
+});

--- a/src/parsers/Confluence.ts
+++ b/src/parsers/Confluence.ts
@@ -3,7 +3,19 @@ import { Link } from "../Link";
 
 export class Confluence extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
-        var linkText = `TODO`;
+        const bodyElement: HTMLElement | null = doc.querySelector(
+            "#com-atlassian-confluence"
+        );
+        if (!bodyElement) {
+            return null;
+        }
+
+        const titleElement: HTMLElement | null =
+            doc.querySelector("#title-text");
+        if (!titleElement || !titleElement.textContent) {
+            return null;
+        }
+        var linkText = titleElement.textContent.trim();
         const result: Link = {
             text: linkText,
             destination: url,

--- a/src/parsers/Confluence.ts
+++ b/src/parsers/Confluence.ts
@@ -1,0 +1,13 @@
+import { AbstractParser } from "./AbstractParser";
+import { Link } from "../Link";
+
+export class Confluence extends AbstractParser {
+    parseLink(doc: Document, url: string): Link | null {
+        var linkText = `TODO`;
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
+    }
+}


### PR DESCRIPTION
# Manual testing

## Given

I created a special userscript from the output of `npm run build`.

## When

I visit https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages and activate the script.

## Then

The following pop-up appears:

![image](https://user-images.githubusercontent.com/297515/213465512-4ca3a12a-ef0c-4b95-9a1f-9c484ef32378.png)

Mission accomplished!