### PR TITLE
Jira folder

### DIFF
--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -82,6 +82,41 @@ test("should parse an issue page hosted under a folder", () => {
     );
 });
 
+test("should parse an issue page hosted under many folders", () => {
+    const html = `
+<html>
+    <head>
+        <title>[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA</title>
+        <link rel="search" type="application/opensearchdescription+xml" href="/jira/osd.jsp" title="[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA">
+    </head>
+    <body>
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">Invalid 'expires' attribute</h1>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://issues.apache.org/jira/path/prefix/browse/HTTPCLIENT-1763"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://issues.apache.org/jira/path/prefix/browse/HTTPCLIENT-1763"
+    );
+    assert.equal(
+        actual?.text,
+        "HTTPCLIENT-1763: Invalid 'expires' attribute"
+    );
+});
+
 test("should parse a title from a custom JIRA deployment", () => {
     const html = `
 <html>

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -47,6 +47,41 @@ test("should parse a simple issue page", () => {
     );
 });
 
+test("should parse an issue page hosted under a folder", () => {
+    const html = `
+<html>
+    <head>
+        <title>[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA</title>
+        <link rel="search" type="application/opensearchdescription+xml" href="/jira/osd.jsp" title="[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA">
+    </head>
+    <body>
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">Invalid 'expires' attribute</h1>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://issues.apache.org/jira/browse/HTTPCLIENT-1763"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://issues.apache.org/jira/browse/HTTPCLIENT-1763"
+    );
+    assert.equal(
+        actual?.text,
+        "HTTPCLIENT-1763: Invalid 'expires' attribute"
+    );
+});
+
 test("should parse a title from a custom JIRA deployment", () => {
     const html = `
 <html>

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -2,7 +2,7 @@ import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
 
 const issueUrlRegex =
-    /https:\/\/(?<host>[^/]+)\/browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
+    /https:\/\/(?<host>[^/]+)\/([^/]+\/)?browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
 export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const issueUrlMatch = url.match(issueUrlRegex);

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -2,7 +2,7 @@ import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
 
 const issueUrlRegex =
-    /https:\/\/(?<host>[^/]+)\/([^/]+\/)?browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
+    /https:\/\/(?<host>[^/]+)\/([^/]+\/)*browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
 export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const issueUrlMatch = url.match(issueUrlRegex);


### PR DESCRIPTION
I noticed the `Jira` parser wasn't parsing successfully when visiting https://issues.apache.org/jira/browse/HTTPCLIENT-1763 and it turns out this was the first JIRA instance I encountered which didn't have its URL path start with `/browse/`, which is now fixed.