### PR TITLE
Improve clipboard support

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
         ],
         "connect": [],
         "require": [],
-        "grant": [],
+        "grant": [
+            "GM_setClipboard"
+        ],
         "exclude": [],
         "resources": []
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,16 +57,6 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             selectedRenderer = renderers[2];
         }
         const clipboard: Clipboard = selectedRenderer.render(link);
-        var clipboardItemVersions: { [id: string]: Blob } = {};
-        clipboardItemVersions["text/plain"] = new Blob([clipboard.text], {
-            type: "text/plain",
-        });
-
-        if (clipboard.html !== null) {
-            clipboardItemVersions["text/html"] = new Blob([clipboard.html], {
-                type: "text/html",
-            });
-        }
 
         if (statusPopup == null) {
             statusPopup = document.createElement("div");
@@ -90,7 +80,7 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             `<br />Text: ${link.text}` +
             `<br />Rendered with ${selectedRenderer.constructor["name"]}.`;
         var result: any = null;
-        result = await copyWithAsyncClipboardApi(clipboardItemVersions);
+        result = await copyWithAsyncClipboardApi(clipboard);
         if (result == null) {
             const successHtml = `${status}<br />Success!`;
             showStatusPopup(successHtml);
@@ -110,12 +100,19 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
  * Restrictions: only works when the page is served over a secure channel (or via localhost)
  * as per https://stackoverflow.com/a/65996386/98903
  *
- * @param clipboardItemVersions a special data object that the ClipboardItem
- *                              constructor needs to carry out the write.
+ * @param clipboard an instance of Clipboard with the data to copy
  */
-async function copyWithAsyncClipboardApi(clipboardItemVersions: {
-    [id: string]: Blob;
-}): Promise<any> {
+async function copyWithAsyncClipboardApi(clipboard: Clipboard): Promise<any> {
+    var clipboardItemVersions: { [id: string]: Blob } = {};
+    clipboardItemVersions["text/plain"] = new Blob([clipboard.text], {
+        type: "text/plain",
+    });
+
+    if (clipboard.html !== null) {
+        clipboardItemVersions["text/html"] = new Blob([clipboard.html], {
+            type: "text/html",
+        });
+    }
     const clipboardItem = new ClipboardItem(clipboardItemVersions);
     const data = [clipboardItem];
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,12 +84,12 @@ function handleKeydown(this: Window, e: KeyboardEvent) {
             statusPopup.attributes.setNamedItem(styleAttribute);
             document.body.appendChild(statusPopup);
         }
-        const clipboardItem = new ClipboardItem(clipboardItemVersions);
         const status =
             `Parsed using ${selectedParser.constructor["name"]}:` +
             `<br />Destination: ${link.destination}` +
             `<br />Text: ${link.text}` +
             `<br />Rendered with ${selectedRenderer.constructor["name"]}.`;
+        const clipboardItem = new ClipboardItem(clipboardItemVersions);
         const data = [clipboardItem];
         navigator.clipboard.write(data).then(
             () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,9 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             `<br />Rendered with ${selectedRenderer.constructor["name"]}.`;
         var result: any = null;
         result = await copyWithAsyncClipboardApi(clipboard);
+        if (result != null) {
+            result = await copyWithGreaseMonkeyClipboardApi(clipboard);
+        }
         if (result == null) {
             const successHtml = `${status}<br />Success!`;
             showStatusPopup(successHtml);
@@ -91,6 +94,17 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             showStatusPopup(failureHtml);
         }
     }
+}
+
+async function copyWithGreaseMonkeyClipboardApi(
+    clipboard: Clipboard
+): Promise<any> {
+    if (clipboard.html !== null) {
+        GM_setClipboard(clipboard.html, "html");
+    } else {
+        GM_setClipboard(clipboard.text, "text");
+    }
+    return null;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,11 @@ import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
 import { Html } from "./renderers/Html";
 import { Jira } from "./parsers/Jira";
-import { ServiceDesk } from "./parsers/ServiceDesk";
-import { ServiceNow } from "./parsers/ServiceNow";
 import { Link } from "./Link";
 import { Markdown } from "./renderers/Markdown";
 import { Renderer } from "./Renderer";
+import { ServiceDesk } from "./parsers/ServiceDesk";
+import { ServiceNow } from "./parsers/ServiceNow";
 import { Textile } from "./renderers/Textile";
 import { Parser } from "./Parser";
 


### PR DESCRIPTION
It's tiring to explicitly give the page focus or to be prevented from copying to the clipboard on sites not hosted via HTTPS, so we fallback to the GreaseMonkey clipboard API if the async Clipboard API refuses to work.