### PR TITLE
feat: add Jenkins support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Default } from "./parsers/Default";
 import { GitHub } from "./parsers/GitHub";
 import { Html } from "./renderers/Html";
 import { Jira } from "./parsers/Jira";
+import { Jenkins } from "./parsers/Jenkins";
 import { Link } from "./Link";
 import { Markdown } from "./renderers/Markdown";
 import { Renderer } from "./Renderer";
@@ -22,6 +23,7 @@ const parsers: Parser[] = [
     new GitHub(),
     new Bitbucket(),
     new Jira(),
+    new Jenkins(),
     new ServiceDesk(),
     new ServiceNow(),
     // always keep this one LAST in this list!

--- a/src/parsers/Jenkins.spec.ts
+++ b/src/parsers/Jenkins.spec.ts
@@ -1,0 +1,415 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { Jenkins } from "./Jenkins";
+
+function testParseLink(html: string, url: string): Link | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: Parser = new Jenkins();
+
+    const actual: Link | null = cut.parseLink(document, url);
+    return actual;
+}
+
+test("job page", () => {
+    const html = `
+<html>
+    <head>
+        <title>Branch [Project » Repository] [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div
+            id="breadcrumbBar"
+            class="jenkins-breadcrumbs"
+            aria-label="breadcrumb"
+            >
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/" class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/job/Branch/" class="children"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/"
+    );
+    assert.equal(actual?.text, "Project » Repository » Branch");
+});
+
+test("run page", () => {
+    const html = `
+<html>
+    <head>
+        <title>Project » Repository » Branch #1 [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div
+            id="breadcrumbBar"
+            class="jenkins-breadcrumbs"
+            aria-label="breadcrumb"
+            >
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/" class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/job/Branch/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/1/" class="model-link">
+                        #1
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/"
+    );
+    assert.equal(actual?.text, "Project » Repository » Branch #1");
+});
+
+test("run's Pipeline steps", () => {
+    const html = `
+<html>
+    <head>
+        <title>Project » Repository » Branch #1 Pipeline steps [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div
+            id="breadcrumbBar"
+            class="jenkins-breadcrumbs"
+            aria-label="breadcrumb"
+            >
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/" class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/job/Branch/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/1/" class="model-link">
+                        #1
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/flowGraphTable/"
+                        class=""
+                        >
+                        Pipeline Steps
+                    </a>
+                </li>
+                <li class="separator"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/flowGraphTable/"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/flowGraphTable/"
+    );
+    assert.equal(
+        actual?.text,
+        "Project » Repository » Branch #1 » Pipeline Steps"
+    );
+});
+
+test("run's specific step", () => {
+    const html = `
+<html>
+    <head>
+        <title>Project » Repository » Branch #1 Pipeline steps [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div id="breadcrumbBar" class="jenkins-breadcrumbs" aria-label="breadcrumb">
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/"
+                        class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li
+                    href="/job/Project/job/Repository/job/Branch/"
+                    class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/"
+                        class="model-link">
+                        #1
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/execution/node/5/"
+                        class="model-link">
+                        Stage : Start
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/execution/node/5/"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/execution/node/5/"
+    );
+    assert.equal(
+        actual?.text,
+        "Project » Repository » Branch #1 » Stage : Start"
+    );
+});
+
+test("run's specific step's console output", () => {
+    const html = `
+<html>
+    <head>
+        <title>Project » Repository » Branch #1 Pipeline steps [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div id="breadcrumbBar" class="jenkins-breadcrumbs" aria-label="breadcrumb">
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/"
+                        class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li
+                    href="/job/Project/job/Repository/job/Branch/"
+                    class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/"
+                        class="model-link">
+                        #1
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/execution/node/5/"
+                        class="model-link">
+                        Stage : Start
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a
+                        href="/job/Project/job/Repository/job/Branch/1/execution/node/5/log/"
+                        class="">
+                        Console Output
+                    </a>
+                </li>
+                <li class="separator"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/execution/node/5/log/"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/execution/node/5/log/"
+    );
+    assert.equal(
+        actual?.text,
+        "Project » Repository » Branch #1 » Stage : Start » Console Output"
+    );
+});

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -1,7 +1,8 @@
 import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
 
-const chevron = "»";
+// Right-Pointing Double Angle Quotation Mark
+const chevron = "\u00BB";
 export class Jenkins extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
         const bodyElement: HTMLElement | null = doc.querySelector(

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -1,0 +1,58 @@
+import { AbstractParser } from "./AbstractParser";
+import { Link } from "../Link";
+
+const chevron = "»";
+export class Jenkins extends AbstractParser {
+    parseLink(doc: Document, url: string): Link | null {
+        const bodyElement: HTMLElement | null = doc.querySelector(
+            "html body[id=jenkins]"
+        );
+        if (!bodyElement) {
+            return null;
+        }
+
+        var linkText = ``;
+        const listItems: NodeListOf<HTMLElement> = doc.querySelectorAll(
+            ".jenkins-breadcrumbs__list-item"
+        );
+        listItems.forEach((value: HTMLElement, key: number) => {
+            if (key > 0) {
+                const anchor: HTMLAnchorElement | null =
+                    value.querySelector("a");
+                if (anchor) {
+                    var isUrlToRun = false;
+                    const href: string | null = anchor.getAttribute("href");
+                    if (href) {
+                        const numToTrim = href.endsWith("/") ? 1 : 0;
+                        const relativeUrl = href.substring(
+                            0,
+                            href.length - numToTrim
+                        );
+                        const hrefParts = relativeUrl.split("/");
+                        const lastPart = hrefParts[hrefParts.length - 1];
+                        if (Number.isInteger(Number.parseInt(lastPart, 10))) {
+                            isUrlToRun = !(
+                                "node" === hrefParts[hrefParts.length - 2] &&
+                                "execution" === hrefParts[hrefParts.length - 3]
+                            );
+                        }
+                    }
+                    if (key > 1) {
+                        if (isUrlToRun) {
+                            linkText += ` `;
+                        } else {
+                            linkText += ` ${chevron} `;
+                        }
+                    }
+                    linkText += anchor.text.trim();
+                }
+            }
+        });
+
+        const result: Link = {
+            text: linkText,
+            destination: url,
+        };
+        return result;
+    }
+}


### PR DESCRIPTION
## Commits

1. feat: add Jenkins parser, with tests
1. feat: wire up Jenkins parser
1. fix: use Unicode escape sequence for chevron
    Otherwise it was "compiled" into an atrocity.

# Manual testing

Using Jenkins 2.387.1 (running from the container) with a very simple job under a couple of folders to simulate the structure the "Organization Folder" plugin would do.
1. Job page: ![image](https://user-images.githubusercontent.com/297515/230694445-321b93c3-993e-4489-83a7-4b932d3256fa.png)
2. Run page: ![image](https://user-images.githubusercontent.com/297515/230694480-d90a53ad-e462-4ca5-9a09-14089b617b5d.png)
3. Run's "Pipeline Steps" page: ![image](https://user-images.githubusercontent.com/297515/230694546-f21f00d7-b700-4714-8b92-5ac0db769b0d.png)
4. Run's specific pipeline step: ![image](https://user-images.githubusercontent.com/297515/230694584-9ec8ed0a-746d-4465-a1a6-d4ef476c3cd6.png)
5. The console output of a specific step in a run: ![image](https://user-images.githubusercontent.com/297515/230694652-9ef0a9c6-9d36-4dcf-8b71-a4268a5cf398.png)
6. The run's console output: ![image](https://user-images.githubusercontent.com/297515/230694694-2b4d37e1-0d60-4033-b87d-99ef211874df.png)