### PR TITLE
feat: Copy as Markdown

### DIFF
--- a/src/Action.ts
+++ b/src/Action.ts
@@ -1,3 +1,3 @@
 export interface Action {
-    perform(doc: Document, url: string): boolean;
+    perform(doc: Document, url: string): Promise<boolean>;
 }

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -1,3 +1,3 @@
 export interface Action {
-    perform(doc: Document, url: string): Promise<boolean>;
+    perform(doc: Document, url: string, e : KeyboardEvent): Promise<boolean>;
 }

--- a/src/actions/CopyUrl.ts
+++ b/src/actions/CopyUrl.ts
@@ -1,0 +1,129 @@
+import { Action } from "../Action";
+import { Bitbucket } from "../parsers/Bitbucket";
+import { Clipboard } from "../Clipboard";
+import { Confluence } from "../parsers/Confluence";
+import { Default } from "../parsers/Default";
+import { GitHub } from "../parsers/GitHub";
+import { Jenkins } from "../parsers/Jenkins";
+import { Jira } from "../parsers/Jira";
+import { Link } from "../Link";
+import { Parser } from "../Parser";
+import { Renderer } from "../Renderer";
+import { ServiceDesk } from "../parsers/ServiceDesk";
+import { ServiceNow } from "../parsers/ServiceNow";
+
+// parsers will be attempted in the order defined here
+const parsers: Parser[] = [
+    new Confluence(),
+    new GitHub(),
+    new Bitbucket(),
+    new Jira(),
+    new Jenkins(),
+    new ServiceDesk(),
+    new ServiceNow(),
+    // always keep this one LAST in this list!
+    new Default(),
+];
+
+export class CopyUrl implements Action {
+    statusPopup: HTMLDivElement;
+    selectedRenderer: Renderer;
+
+    constructor(statusPopup: HTMLDivElement, selectedRenderer: Renderer) {
+        this.statusPopup = statusPopup;
+        this.selectedRenderer = selectedRenderer;
+    }
+
+    async perform(
+        doc: Document,
+        url: string,
+        e: KeyboardEvent
+    ): Promise<boolean> {
+        e.preventDefault();
+        console.log("asking the parsers...");
+        var link: Link = {
+            text: url,
+            destination: url,
+        };
+        var selectedParser: Parser = parsers[parsers.length - 1];
+        for (let i = 0; i < parsers.length; i++) {
+            const parser = parsers[i];
+            selectedParser = parser;
+            var candidate: Link | null = parser.parseLink(doc, url);
+            if (candidate) {
+                link = candidate;
+                break;
+            }
+        }
+        const clipboard: Clipboard = this.selectedRenderer.render(link);
+
+        const status =
+            `Parsed using ${selectedParser.constructor["name"]}:` +
+            `<br />Destination: ${link.destination}` +
+            `<br />Text: ${link.text}` +
+            `<br />Rendered with ${this.selectedRenderer.constructor["name"]}.`;
+        var result: any = null;
+        result = await this.copyWithAsyncClipboardApi(clipboard);
+        if (result != null) {
+            result = await this.copyWithGreaseMonkeyClipboardApi(clipboard);
+        }
+        if (result == null) {
+            const successHtml = `${status}<br />Success!`;
+            this.showStatusPopup(successHtml);
+        } else {
+            const failureHtml =
+                `${status}<br />` +
+                `<span style="color:darkred">Failure: ${result}</span>`;
+            this.showStatusPopup(failureHtml);
+        }
+        return true;
+    }
+
+    async copyWithGreaseMonkeyClipboardApi(clipboard: Clipboard): Promise<any> {
+        if (clipboard.html !== null) {
+            GM_setClipboard(clipboard.html, "html");
+        } else {
+            GM_setClipboard(clipboard.text, "text");
+        }
+        return null;
+    }
+
+    /**
+     * Attempts to copy the specified data to the clipboard using the standardized (async)
+     * Clipboard API as per https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
+     *
+     * Restrictions: only works when the page is served over a secure channel (or via localhost)
+     * as per https://stackoverflow.com/a/65996386/98903
+     *
+     * @param clipboard an instance of Clipboard with the data to copy
+     */
+    async copyWithAsyncClipboardApi(clipboard: Clipboard): Promise<any> {
+        var clipboardItemVersions: { [id: string]: Blob } = {};
+        clipboardItemVersions["text/plain"] = new Blob([clipboard.text], {
+            type: "text/plain",
+        });
+
+        if (clipboard.html !== null) {
+            clipboardItemVersions["text/html"] = new Blob([clipboard.html], {
+                type: "text/html",
+            });
+        }
+        try {
+            const clipboardItem = new ClipboardItem(clipboardItemVersions);
+            const data = [clipboardItem];
+            await navigator.clipboard.write(data);
+            return null;
+        } catch (error) {
+            console.log(error);
+            return error;
+        }
+    }
+
+    showStatusPopup(innerHTML: string) {
+        // TODO: fade in?
+        this.statusPopup.innerHTML = innerHTML;
+        this.statusPopup.style.display = "block";
+        window.setTimeout(() => this.statusPopup.style.display = "none", 5000 /*ms*/);
+        console.log(innerHTML);
+    }
+}

--- a/src/actions/GoToAction.ts
+++ b/src/actions/GoToAction.ts
@@ -1,7 +1,7 @@
 import { Action } from "../Action";
 
 export abstract class GoToAction implements Action {
-    perform(doc: Document, url: string): boolean {
+    async perform(doc: Document, url: string): Promise<boolean> {
         const result: string | null = this.navigate(doc, url);
         if (result) {
             window.location.href = result;

--- a/src/actions/GoToAction.ts
+++ b/src/actions/GoToAction.ts
@@ -1,7 +1,11 @@
 import { Action } from "../Action";
 
 export abstract class GoToAction implements Action {
-    async perform(doc: Document, url: string): Promise<boolean> {
+    async perform(
+        doc: Document,
+        url: string,
+        e: KeyboardEvent
+    ): Promise<boolean> {
         const result: string | null = this.navigate(doc, url);
         if (result) {
             window.location.href = result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,22 +43,6 @@ class CopyUrlAction implements Action {
         var selectedRenderer: Renderer = new Html();
         const clipboard: Clipboard = selectedRenderer.render(link);
 
-        if (statusPopup == null) {
-            statusPopup = doc.createElement("div");
-            const styleAttribute = doc.createAttribute("style");
-            styleAttribute.value = `
-                position: fixed;
-                top:0;
-                right: 0;
-                z-index: 65535;
-                color: black;
-                background-color: white;
-                padding: 5px;
-                display: none;
-            `;
-            statusPopup.attributes.setNamedItem(styleAttribute);
-            doc.body.appendChild(statusPopup);
-        }
         const status =
             `Parsed using ${selectedParser.constructor["name"]}:` +
             `<br />Destination: ${link.destination}` +
@@ -204,6 +188,23 @@ function hideStatusPopup() {
 }
 
 async function main(): Promise<void> {
+    if (statusPopup == null) {
+        var doc = window.document;
+        statusPopup = doc.createElement("div");
+        const styleAttribute = doc.createAttribute("style");
+        styleAttribute.value = `
+            position: fixed;
+            top:0;
+            right: 0;
+            z-index: 65535;
+            color: black;
+            background-color: white;
+            padding: 5px;
+            display: none;
+        `;
+        statusPopup.attributes.setNamedItem(styleAttribute);
+        doc.body.appendChild(statusPopup);
+    }
     window.addEventListener("keydown", handleKeydown);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             if (actionList) {
                 var handled = false;
                 for (const action of actionList) {
-                    handled = await action.perform(document, url);
+                    handled = await action.perform(document, url, e);
                     if (handled) {
                         break;
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,14 +120,17 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
         );
         if (shortcuts.has(shortcutString)) {
             const actionList = shortcuts.get(shortcutString);
-            var handled = false;
-            actionList?.forEach(async (action) => {
-                if (!handled) {
+            if (actionList) {
+                var handled = false;
+                for (const action of actionList) {
                     handled = await action.perform(document, url);
+                    if (handled) {
+                        break;
+                    }
                 }
-            });
-            if (handled) {
-                e.preventDefault();
+                if (handled) {
+                    e.preventDefault();
+                }
             }
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,10 +64,10 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
             }
         }
         var selectedRenderer: Renderer = renderers[0];
-        if (!e.altKey) {
-            selectedRenderer = renderers[0];
-        } else {
+        if (e.altKey) {
             selectedRenderer = renderers[2];
+        } else {
+            selectedRenderer = renderers[0];
         }
         const clipboard: Clipboard = selectedRenderer.render(link);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,9 +121,9 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
         if (shortcuts.has(shortcutString)) {
             const actionList = shortcuts.get(shortcutString);
             var handled = false;
-            actionList?.forEach((action) => {
+            actionList?.forEach(async (action) => {
                 if (!handled) {
-                    handled = action.perform(document, url);
+                    handled = await action.perform(document, url);
                 }
             });
             if (handled) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,71 +1,13 @@
 // Keep this list sorted!
 import { Action } from "./Action";
-import { Bitbucket } from "./parsers/Bitbucket";
-import { Clipboard } from "./Clipboard";
-import { Confluence } from "./parsers/Confluence";
-import { Default } from "./parsers/Default";
-import { GitHub } from "./parsers/GitHub";
+import { CopyUrl } from "./actions/CopyUrl";
 import { Html } from "./renderers/Html";
-import { Jira } from "./parsers/Jira";
 import { JiraWorklog } from "./actions/JiraWorklog";
-import { Jenkins } from "./parsers/Jenkins";
 import { KeyboardShortcut } from "./KeyboardShortcut";
-import { Link } from "./Link";
 import { Markdown } from "./renderers/Markdown";
-import { Renderer } from "./Renderer";
-import { ServiceDesk } from "./parsers/ServiceDesk";
-import { ServiceNow } from "./parsers/ServiceNow";
 import { Textile } from "./renderers/Textile";
-import { Parser } from "./Parser";
 
-class CopyUrlAction implements Action {
-    async perform(
-        doc: Document,
-        url: string,
-        e: KeyboardEvent
-    ): Promise<boolean> {
-        e.preventDefault();
-        console.log("asking the parsers...");
-        var link: Link = {
-            text: url,
-            destination: url,
-        };
-        var selectedParser: Parser = parsers[parsers.length - 1];
-        for (let i = 0; i < parsers.length; i++) {
-            const parser = parsers[i];
-            selectedParser = parser;
-            var candidate: Link | null = parser.parseLink(doc, url);
-            if (candidate) {
-                link = candidate;
-                break;
-            }
-        }
-        var selectedRenderer: Renderer = new Html();
-        const clipboard: Clipboard = selectedRenderer.render(link);
-
-        const status =
-            `Parsed using ${selectedParser.constructor["name"]}:` +
-            `<br />Destination: ${link.destination}` +
-            `<br />Text: ${link.text}` +
-            `<br />Rendered with ${selectedRenderer.constructor["name"]}.`;
-        var result: any = null;
-        result = await copyWithAsyncClipboardApi(clipboard);
-        if (result != null) {
-            result = await copyWithGreaseMonkeyClipboardApi(clipboard);
-        }
-        if (result == null) {
-            const successHtml = `${status}<br />Success!`;
-            showStatusPopup(successHtml);
-        } else {
-            const failureHtml =
-                `${status}<br />` +
-                `<span style="color:darkred">Failure: ${result}</span>`;
-            showStatusPopup(failureHtml);
-        }
-
-        return true;
-    }
-}
+const statusPopup: HTMLDivElement = window.document.createElement("div");
 
 // prettier-ignore
 const shortcuts : Map<string, Array<Action>> = new Map([
@@ -76,25 +18,11 @@ const shortcuts : Map<string, Array<Action>> = new Map([
     ],
     [
         KeyboardShortcut.asString(true, false, false, "o"), [
-            new CopyUrlAction(),
+            new CopyUrl(statusPopup, new Html()),
         ]
     ],
 ]);
 
-// parsers will be attempted in the order defined here
-const parsers: Parser[] = [
-    new Confluence(),
-    new GitHub(),
-    new Bitbucket(),
-    new Jira(),
-    new Jenkins(),
-    new ServiceDesk(),
-    new ServiceNow(),
-    // always keep this one LAST in this list!
-    new Default(),
-];
-
-var statusPopup: HTMLDivElement | null;
 async function handleKeydown(this: Window, e: KeyboardEvent) {
     const document: Document = window.document;
     const url: string = window.location.href;
@@ -128,83 +56,22 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
     }
 }
 
-async function copyWithGreaseMonkeyClipboardApi(
-    clipboard: Clipboard
-): Promise<any> {
-    if (clipboard.html !== null) {
-        GM_setClipboard(clipboard.html, "html");
-    } else {
-        GM_setClipboard(clipboard.text, "text");
-    }
-    return null;
-}
-
-/**
- * Attempts to copy the specified data to the clipboard using the standardized (async)
- * Clipboard API as per https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
- *
- * Restrictions: only works when the page is served over a secure channel (or via localhost)
- * as per https://stackoverflow.com/a/65996386/98903
- *
- * @param clipboard an instance of Clipboard with the data to copy
- */
-async function copyWithAsyncClipboardApi(clipboard: Clipboard): Promise<any> {
-    var clipboardItemVersions: { [id: string]: Blob } = {};
-    clipboardItemVersions["text/plain"] = new Blob([clipboard.text], {
-        type: "text/plain",
-    });
-
-    if (clipboard.html !== null) {
-        clipboardItemVersions["text/html"] = new Blob([clipboard.html], {
-            type: "text/html",
-        });
-    }
-    try {
-        const clipboardItem = new ClipboardItem(clipboardItemVersions);
-        const data = [clipboardItem];
-        await navigator.clipboard.write(data);
-        return null;
-    } catch (error) {
-        console.log(error);
-        return error;
-    }
-}
-
-function showStatusPopup(innerHTML: string) {
-    if (statusPopup != null) {
-        // TODO: fade in?
-        statusPopup.innerHTML = innerHTML;
-        statusPopup.style.display = "block";
-        window.setTimeout(hideStatusPopup, 5000 /*ms*/);
-    }
-    console.log(innerHTML);
-}
-
-function hideStatusPopup() {
-    if (statusPopup != null) {
-        // TODO: fade out?
-        statusPopup.style.display = "none";
-    }
-}
-
 async function main(): Promise<void> {
-    if (statusPopup == null) {
-        var doc = window.document;
-        statusPopup = doc.createElement("div");
-        const styleAttribute = doc.createAttribute("style");
-        styleAttribute.value = `
-            position: fixed;
-            top:0;
-            right: 0;
-            z-index: 65535;
-            color: black;
-            background-color: white;
-            padding: 5px;
-            display: none;
-        `;
-        statusPopup.attributes.setNamedItem(styleAttribute);
-        doc.body.appendChild(statusPopup);
-    }
+    var doc = window.document;
+    const styleAttribute = doc.createAttribute("style");
+    styleAttribute.value = `
+        position: fixed;
+        top:0;
+        right: 0;
+        z-index: 65535;
+        color: black;
+        background-color: white;
+        padding: 5px;
+        display: none;
+    `;
+    statusPopup.attributes.setNamedItem(styleAttribute);
+    doc.body.appendChild(statusPopup);
+
     window.addEventListener("keydown", handleKeydown);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,16 @@ const shortcuts : Map<string, Array<Action>> = new Map([
     ],
     [
         KeyboardShortcut.asString(true, false, false, "o"), [
+            new CopyUrl(statusPopup, new Markdown()),
+        ]
+    ],
+    [
+        KeyboardShortcut.asString(true, true, false, "o"), [
+            new CopyUrl(statusPopup, new Textile()),
+        ]
+    ],
+    [
+        KeyboardShortcut.asString(true, true, false, "p"), [
             new CopyUrl(statusPopup, new Html()),
         ]
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,9 +164,9 @@ async function copyWithAsyncClipboardApi(clipboard: Clipboard): Promise<any> {
             type: "text/html",
         });
     }
-    const clipboardItem = new ClipboardItem(clipboardItemVersions);
-    const data = [clipboardItem];
     try {
+        const clipboardItem = new ClipboardItem(clipboardItemVersions);
+        const data = [clipboardItem];
         await navigator.clipboard.write(data);
         return null;
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ async function copyWithAsyncClipboardApi(clipboard: Clipboard): Promise<any> {
         await navigator.clipboard.write(data);
         return null;
     } catch (error) {
+        console.log(error);
         return error;
     }
 }


### PR DESCRIPTION
Markdown is now the default renderer for the `Ctrl+o` shortcut. The HTML renderer is now triggered by `Ctrl+Alt+p`.  Refactoring shuffled and simplified the code to use the `Action` mechanism, which had to be altered to cancel the default action earlier, otherwise sometimes the "Open" dialog would pop up.