### PR TITLE
feat: special URL text for a Jenkins run's console output

### DIFF
--- a/src/parsers/Jenkins.spec.ts
+++ b/src/parsers/Jenkins.spec.ts
@@ -13,6 +13,22 @@ function testParseLink(html: string, url: string): Link | null {
     return actual;
 }
 
+test("splitUrlPath with deep URL", () => {
+    const input = "http://localhost:8080/job/Project/job/Repository/job/Branch/";
+    const cut = new Jenkins();
+
+    const actual = cut.splitUrlPath(input);
+
+    assert.equal(actual.length, 7);
+    assert.equal(actual[0], "");
+    assert.equal(actual[1], "job");
+    assert.equal(actual[2], "Project");
+    assert.equal(actual[3], "job");
+    assert.equal(actual[4], "Repository");
+    assert.equal(actual[5], "job");
+    assert.equal(actual[6], "Branch");
+});
+
 test("job page", () => {
     const html = `
 <html>

--- a/src/parsers/Jenkins.spec.ts
+++ b/src/parsers/Jenkins.spec.ts
@@ -166,6 +166,78 @@ test("run page", () => {
     assert.equal(actual?.text, "Project » Repository » Branch #1");
 });
 
+test("run's console output", () => {
+    const html = `
+<html>
+    <head>
+        <title>Project » Repository » Branch #1 Console [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+        <!-- etc., etc... -->
+        <div
+            id="breadcrumbBar"
+            class="jenkins-breadcrumbs"
+            aria-label="breadcrumb"
+            >
+            <ol class="jenkins-breadcrumbs__list" id="breadcrumbs">
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/" class="model-link">
+                        Dashboard
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/" class="model-link">
+                        Project
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/" class="model-link">
+                        Repository
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/" class="model-link">
+                        Branch
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li href="/job/Project/job/Repository/job/Branch/" class="children"></li>
+                <li class="jenkins-breadcrumbs__list-item">
+                    <a href="/job/Project/job/Repository/job/Branch/1/" class="model-link">
+                        #1
+                        <span class="jenkins-menu-dropdown-chevron"></span>
+                    </a>
+                </li>
+                <li class="separator"></li>
+            </ol>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/console"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/1/console"
+    );
+    assert.equal(actual?.text, "Project » Repository » Branch #1 » Console Output");
+});
+
 test("run page, version 2.361.4", () => {
     const html = `
 <html>

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -11,6 +11,10 @@ export class Jenkins extends AbstractParser {
         return pathParts;
     }
 
+    isInteger(s: string): boolean {
+        return Number.isInteger(Number.parseInt(s, 10));
+    }
+
     parseLink(doc: Document, url: string): Link | null {
         const bodyElement: HTMLElement | null = doc.querySelector(
             "html body[id=jenkins]"
@@ -39,7 +43,7 @@ export class Jenkins extends AbstractParser {
                     if (href) {
                         const hrefParts = this.splitPath(href);
                         const lastPart = hrefParts[hrefParts.length - 1];
-                        if (Number.isInteger(Number.parseInt(lastPart, 10))) {
+                        if (this.isInteger(lastPart)) {
                             isUrlToRun = !(
                                 "node" === hrefParts[hrefParts.length - 2] &&
                                 "execution" === hrefParts[hrefParts.length - 3]

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -35,6 +35,10 @@ export class Jenkins extends AbstractParser {
                 selector = ".jenkins-breadcrumbs .item";
                 break;
         }
+        const urlParts = this.splitUrlPath(url);
+        const isUrlToRunConsole =
+            "console" === urlParts[urlParts.length - 1] &&
+            this.isInteger(urlParts[urlParts.length - 2]);
         var linkText = ``;
         const listItems: NodeListOf<HTMLElement> =
             doc.querySelectorAll(selector);
@@ -63,6 +67,9 @@ export class Jenkins extends AbstractParser {
                         }
                     }
                     linkText += anchor.text.trim();
+                    if (key == listItems.length - 1 && isUrlToRunConsole) {
+                        linkText += ` ${chevron} Console Output`;
+                    }
                 }
             }
         });

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -11,6 +11,11 @@ export class Jenkins extends AbstractParser {
         return pathParts;
     }
 
+    splitUrlPath(urlString: string): string[] {
+        const url = new URL(urlString);
+        return this.splitPath(url.pathname);
+    }
+
     isInteger(s: string): boolean {
         return Number.isInteger(Number.parseInt(s, 10));
     }

--- a/src/parsers/Jenkins.ts
+++ b/src/parsers/Jenkins.ts
@@ -4,6 +4,13 @@ import { Link } from "../Link";
 // Right-Pointing Double Angle Quotation Mark
 const chevron = "\u00BB";
 export class Jenkins extends AbstractParser {
+    splitPath(path: string): string[] {
+        const numToTrim = path.endsWith("/") ? 1 : 0;
+        const adjustedPath = path.substring(0, path.length - numToTrim);
+        const pathParts = adjustedPath.split("/");
+        return pathParts;
+    }
+
     parseLink(doc: Document, url: string): Link | null {
         const bodyElement: HTMLElement | null = doc.querySelector(
             "html body[id=jenkins]"
@@ -30,12 +37,7 @@ export class Jenkins extends AbstractParser {
                     var isUrlToRun = false;
                     const href: string | null = anchor.getAttribute("href");
                     if (href) {
-                        const numToTrim = href.endsWith("/") ? 1 : 0;
-                        const relativeUrl = href.substring(
-                            0,
-                            href.length - numToTrim
-                        );
-                        const hrefParts = relativeUrl.split("/");
+                        const hrefParts = this.splitPath(href);
                         const lastPart = hrefParts[hrefParts.length - 1];
                         if (Number.isInteger(Number.parseInt(lastPart, 10))) {
                             isUrlToRun = !(


### PR DESCRIPTION
# Manual testing

![image](https://user-images.githubusercontent.com/297515/231921043-9cc71594-7f7e-4134-9401-44366720b415.png)

In other words, it rendered this:
```markdown
[Project » Repository » Branch #1 » Console Output](http://localhost:8080/job/Project/job/Repository/job/Branch/1/console)
```

Mission accomplished!