### PR TITLE
feat: JiraLinkItem, activated by 'l'

### DIFF
--- a/src/actions/JiraLinkIssue.spec.ts
+++ b/src/actions/JiraLinkIssue.spec.ts
@@ -1,0 +1,74 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { JiraLinkIssue } from "./JiraLinkIssue";
+import { GoToAction } from "./GoToAction";
+
+function testNavigate(html: string, url: string): string | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut: GoToAction = new JiraLinkIssue();
+
+    const actual: string | null = cut.navigate(document, url);
+    return actual;
+}
+
+test("JIRA", () => {
+    const html = `
+<html>
+    <head>
+        <title>
+            [PIG-1] The Chicken contributed, the Pig committed - Your Company Jira
+        </title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="page">
+            <div id="content">
+                <!-- etc., etc... -->
+                <aui-dropdown-menu
+                    id="opsbar-operations_more_drop"
+                    resolved=""
+                    role="menu"
+                    class="aui-dropdown2 aui-layer"
+                    tabindex="-1"
+                    >
+                    <aui-section resolved="" class="aui-dropdown2-section">
+                        <div class="aui-dropdown2-item-group" role="group">
+                            <aui-item-link
+                                href="/jira/secure/LinkJiraIssue!default.jspa?id=10000"
+                                id="link-issue"
+                                class="issueaction-link-issue"
+                                title="Link this issue to another issue or item"
+                                resolved=""
+                                >
+                                <a
+                                    role="menuitem"
+                                    tabindex="-1"
+                                    href="/jira/secure/LinkJiraIssue!default.jspa?id=10000">
+                                    <span class="trigger-label">
+                                        Link
+                                    </span>
+                                </a>
+                            </aui-item-link>
+                        </div>
+                    </aui-section>
+                </aui-dropdown-menu>
+            </div>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testNavigate(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.equal(
+        actual,
+        "http://localhost:2990/jira/secure/LinkJiraIssue!default.jspa?id=10000"
+    );
+});

--- a/src/actions/JiraLinkIssue.ts
+++ b/src/actions/JiraLinkIssue.ts
@@ -1,0 +1,19 @@
+import { GoToAction } from "./GoToAction";
+
+export class JiraLinkIssue extends GoToAction {
+    navigate(doc: Document, url: string): string | null {
+        const baseUrl = new URL(url);
+        baseUrl.pathname = "";
+        const anchor: HTMLAnchorElement | null = doc.querySelector(
+            "aui-item-link#link-issue a"
+        );
+        if (anchor) {
+            const path: string | null = anchor.getAttribute("href");
+            if (path) {
+                const destinationUrl = new URL(path, baseUrl);
+                return destinationUrl.toString();
+            }
+        }
+        return null;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { JenkinsConfigure } from "./actions/JenkinsConfigure";
 import { JenkinsConsole } from "./actions/JenkinsConsole";
 import { JenkinsCredentials } from "./actions/JenkinsCredentials";
 import { JenkinsDashboard } from "./actions/JenkinsDashboard";
+import { JiraLinkIssue } from "./actions/JiraLinkIssue";
 import { JenkinsNext } from "./actions/JenkinsNext";
 import { JenkinsPipelineSyntax } from "./actions/JenkinsPipelineSyntax";
 import { JenkinsPrevious } from "./actions/JenkinsPrevious";
@@ -39,6 +40,11 @@ const shortcuts : Map<string, Array<Action>> = new Map([
     [
         KeyboardShortcut.asString(false, false, false, "k"), [
             new JenkinsCredentials(),
+        ]
+    ],
+    [
+        KeyboardShortcut.asString(false, false, false, "l"), [
+            new JiraLinkIssue(),
         ]
     ],
     [


### PR DESCRIPTION
Implements #29.

I can now hit the `l` (lowercase `L`) key on my keyboard from a JIRA issue and be taken to its `LinkJiraIssue` page:

![image](https://user-images.githubusercontent.com/297515/235033405-968a10a8-dddc-44c1-8d89-ee18bc0acd37.png)

Mission accomplished!