### PR TITLE
Save in jira

### DIFF
--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -72,6 +72,76 @@ test("JIRA create issue starting point, standalone", () => {
     assert.isNotNull(actual);
 });
 
+test("JIRA create issue details, pop-up", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>[PIG-1] The Chicken contributed, the Pig committed</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="page">
+        </div>
+        <section
+            id="create-subtask-dialog"
+            class="aui-dialog2 aui-layer jira-dialog2 jira-dialog-core aui-dialog2-large jira-dialog-open jira-dialog-content-ready"
+            role="dialog"
+            aria-labelledby="jira-dialog2__heading"
+            style="z-index: 3000"
+            data-aui-focus="false"
+            data-aui-blanketed="true"
+            open=""
+            tabindex="-1"
+            >
+            <footer class="aui-dialog2-footer">
+                <div class="buttons-container form-footer">
+                    <div class="buttons">
+                        <label
+                            for="qf-create-another"
+                            class="qf-create-another"
+                            >
+                            <input id="qf-create-another" type="checkbox" />
+                            Create another
+                        </label>
+                        <input
+                            accesskey="s"
+                            title="Press Alt+Shift+s to submit this form"
+                            class="aui-button aui-button-primary"
+                            id="create-issue-submit"
+                            name="Edit"
+                            type="submit"
+                            value="Create"
+                            form="dialog-form"
+                            resolved=""
+                            />
+                        <button
+                            type="button"
+                            accesskey="\`"
+                            title="Press Alt+Shift+\` to cancel"
+                            class="aui-button aui-button-link cancel"
+                            resolved=""
+                            >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </footer>
+        </section>
+        </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.isNotNull(actual);
+});
+
 test("JIRA create issue details, standalone", () => {
     const html = `
 <html class="mozilla" lang="en">

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -398,6 +398,95 @@ test("JIRA add issue link", () => {
     assert.isNotNull(actual);
 });
 
+test("JIRA add issue link, pop-up", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Link</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="aui-page-panel-content">
+            </main>
+        </div>
+        <div
+            id="link-issue-dialog"
+            class="jira-dialog jira-dialog-core box-shadow jira-dialog-open popup-width-large jira-dialog-content-ready"
+            style="width: 810px; margin-left: -406px; margin-top: -283px">
+            <div class="jira-dialog-heading jira-dialog-core-heading">
+                <h2 title="Link">Link</h2>
+            </div>
+            <div class="jira-dialog-content jira-dialog-core-content">
+                <div class="aui-group">
+                    <div class="aui-item dialog-menu-group">
+                        <ul class="dialog-menu">
+                            <li>
+                                <button
+                                    id="add-jira-issue-link-link"
+                                    data-url="/jira/secure/LinkJiraIssue!default.jspa?id=10000"
+                                    class="dialog-menu-item selected">
+                                    Jira Issue
+                                </button>
+                            </li>
+                            <li>
+                                <button
+                                    id="add-web-link-link"
+                                    data-url="/jira/secure/AddWebLink!default.jspa?id=10000"
+                                    class="dialog-menu-item">
+                                    Web Link
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="aui-item dialog-pane">
+                        <form
+                            action="LinkJiraIssue.jspa"
+                            method="post"
+                            id="link-jira-issue"
+                            class="aui dnd-attachment-support">
+                            <div class="buttons-container form-footer">
+                                <div class="buttons">
+                                    <input
+                                        accesskey="s"
+                                        class="aui-button"
+                                        name="Link"
+                                        title="Press Alt+Shift+s to submit this form"
+                                        type="submit"
+                                        value="Link"
+                                        resolved=""
+                                        />
+                                    <a
+                                        accesskey="\`"
+                                        class="aui-button aui-button-link cancel"
+                                        href="/jira/browse/PIG-1"
+                                        title="Press Alt+Shift+\` to cancel"
+                                        resolved=""
+                                        >
+                                        Cancel
+                                    </a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.isNotNull(actual);
+});
+
 test("JIRA issue add worklog", () => {
     const html = `
 <html class="mozilla" lang="en">

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -208,6 +208,64 @@ test("JIRA edit issue, pop-up", () => {
     assert.isNotNull(actual);
 });
 
+test("JIRA edit issue labels", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Labels: PIG-1</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="/jira/secure/EditLabels.jspa?atl_token=BWP3-NZB2-6EDY-6C7K_80b13c0672eae9ae17aff468822446e8ccedd79d_lin"
+                    class="aui edit-labels"
+                    id="edit-labels-form"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="submit"
+                                name="edit-labels-submit"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Update"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="/jira/browse/PIG-1"
+                                id="cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/secure/EditLabels!default.jspa?id=10000"
+    );
+
+    assert.isNotNull(actual);
+});
+
 test("JIRA edit issue labels, pop-up", () => {
     const html = `
 <html class="mozilla" lang="en">

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -130,3 +130,80 @@ test("JIRA create issue details, standalone", () => {
 
     assert.isNotNull(actual);
 });
+
+test("JIRA edit issue, pop-up", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Edit Issue : PIG-1</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="content">
+                <div class="issue-view">
+                </div>
+            </main>
+        </div>
+        <section
+            id="edit-issue-dialog"
+            class="aui-dialog2 aui-layer jira-dialog2 jira-dialog-core aui-dialog2-large jira-dialog-open jira-dialog-content-ready"
+            role="dialog"
+            aria-labelledby="jira-dialog2__heading"
+            style="z-index: 3000"
+            data-aui-focus="false"
+            data-aui-blanketed="true"
+            open=""
+            tabindex="-1">
+            <header class="aui-dialog2-header jira-dialog-core-heading">
+                <h2 id="jira-dialog2__heading" title="Edit Issue : PIG-1">
+                    Edit Issue : PIG-1
+                </h2>
+            </header>
+            <div class="aui-dialog2-content jira-dialog-core-content">
+                <div class="qf-container">
+                </div>
+                <div class="attach-files-drop-zone__dragover-mask"></div>
+            </div>
+            <footer class="aui-dialog2-footer">
+                <div class="buttons-container form-footer">
+                    <div class="buttons">
+                        <span class="throbber"></span>
+                        <input
+                            accesskey="s"
+                            title="Press Alt+Shift+s to submit this form"
+                            class="button aui-button aui-button-primary"
+                            id="edit-issue-submit"
+                            name="Edit"
+                            type="submit"
+                            value="Update"
+                            form="dialog-form"
+                            resolved=""
+                            />
+                        <button
+                            type="button"
+                            accesskey="\`"
+                            title="Press Alt+Shift+\` to cancel"
+                            class="aui-button aui-button-link cancel"
+                            resolved=""
+                            >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </footer>
+        </section>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -283,3 +283,59 @@ test("JIRA edit issue labels, pop-up", () => {
 
     assert.isNotNull(actual);
 });
+
+test("JIRA add issue link", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Link</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="LinkJiraIssue.jspa"
+                    method="post"
+                    id="link-jira-issue"
+                    class="aui dnd-attachment-support"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                name="Link"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Link"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="/jira/browse/PIG-1"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/secure/LinkJiraIssue!default.jspa?id=10000"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -208,6 +208,65 @@ test("JIRA edit issue, pop-up", () => {
     assert.isNotNull(actual);
 });
 
+test("JIRA edit issue, standalone", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Edit Issue : [PIG-6]</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="/jira/secure/EditIssue.jspa?atl_token=BWP3-NZB2-6EDY-6C7K_e3dba220a134df2d189afefa2aaa822b77b4a6fc_lin"
+                    class="aui"
+                    enctype="multipart/form-data"
+                    id="issue-edit"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="issue-edit-submit"
+                                name="Update"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Update"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="/jira/browse/PIG-6"
+                                id="issue-edit-cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/secure/EditIssue!default.jspa?id=10301"
+    );
+
+    assert.isNotNull(actual);
+});
+
 test("JIRA edit issue labels", () => {
     const html = `
 <html class="mozilla" lang="en">

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -2,12 +2,15 @@ import { assert, test } from "vitest";
 import { JSDOM } from "jsdom";
 import { JiraSave } from "./JiraSave";
 
-function testFindSaveableForm(html: string, url: string): HTMLFormElement | null {
+function testFindSaveButton(
+    html: string,
+    url: string
+): HTMLInputElement | null {
     const dom: JSDOM = new JSDOM(html);
     const document: Document = dom.window.document;
     const cut = new JiraSave();
 
-    const actual = cut.findSaveableForm(document, url);
+    const actual = cut.findSaveButton(document, url);
     return actual;
 }
 
@@ -15,7 +18,7 @@ test("JIRA create issue starting point, standalone", () => {
     const html = `
 <html class="mozilla" lang="en">
     <head>
-        <title>[CHKN-1] This is your first task</title>
+        <title>Create Issue</title>
     </head>
     <body
         id="jira"
@@ -61,9 +64,68 @@ test("JIRA create issue starting point, standalone", () => {
 </html>
 `;
 
-    const actual = testFindSaveableForm(
+    const actual = testFindSaveButton(
         html,
-        "http://localhost:2990/jira/browse/CHKN-1"
+        "http://localhost:2990/jira/secure/CreateIssue!default.jspa"
+    );
+
+    assert.isNotNull(actual);
+});
+
+test("JIRA create issue details, standalone", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Create Issue</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="page">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="CreateIssueDetails.jspa"
+                    class="aui"
+                    enctype="multipart/form-data"
+                    id="issue-create"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="issue-create-submit"
+                                name="Create"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Create"
+                                resolved=""
+                            />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="default.jsp"
+                                id="issue-create-cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/secure/CreateIssueDetails.jspa"
     );
 
     assert.isNotNull(actual);

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -1,0 +1,70 @@
+import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
+import { JiraSave } from "./JiraSave";
+
+function testFindSaveableForm(html: string, url: string): HTMLFormElement | null {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const cut = new JiraSave();
+
+    const actual = cut.findSaveableForm(document, url);
+    return actual;
+}
+
+test("JIRA create issue starting point, standalone", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>[CHKN-1] This is your first task</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="page">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="CreateIssue.jspa"
+                    class="aui"
+                    id="issue-create"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="issue-create-submit"
+                                name="Next"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Next"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="default.jsp"
+                                id="issue-create-cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveableForm(
+        html,
+        "http://localhost:2990/jira/browse/CHKN-1"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -207,3 +207,79 @@ test("JIRA edit issue, pop-up", () => {
 
     assert.isNotNull(actual);
 });
+
+test("JIRA edit issue labels, pop-up", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Labels: PIG-1</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="content">
+                <div class="issue-view">
+                </div>
+            </main>
+        </div>
+        <div class="jira-dialog-content jira-dialog-core-content">
+            <div class="dialog-title hidden">Labels</div>
+            <form
+                action="/jira/secure/EditLabels.jspa?atl_token=BWP3-NZB2-6EDY-6C7K_e34a6a6b54443f624777e87414875b1a3875eb1a_lin"
+                class="aui edit-labels"
+                id="edit-labels-form"
+                method="post"
+                >
+                <div class="form-body" style="max-height: 426px">
+                    <div class="field-group aui-field-labelpicker">
+                        <label for="labels-textarea">
+                            Labels
+                        </label>
+                        <div
+                            class="jira-multi-select long-field"
+                            id="labels-multi-select"
+                            data-query="breakfast">
+                            <span class="icon drop-menu noloading" tabindex="-1"></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="buttons-container form-footer">
+                    <div class="buttons">
+                        <input
+                            accesskey="s"
+                            class="aui-button"
+                            id="submit"
+                            name="edit-labels-submit"
+                            title="Press Alt+Shift+s to submit this form"
+                            type="submit"
+                            value="Update"
+                            resolved=""
+                            />
+                        <a
+                            accesskey="\`"
+                            class="aui-button aui-button-link cancel"
+                            href="/jira/browse/PIG-1"
+                            id="cancel"
+                            title="Press Alt+Shift+\` to cancel"
+                            resolved=""
+                            >
+                            Cancel
+                        </a>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -339,3 +339,61 @@ test("JIRA add issue link", () => {
 
     assert.isNotNull(actual);
 });
+
+test("JIRA issue add worklog", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Log work: PIG-1</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+            <main role="main" id="main" class="aui-page-panel-content">
+                <form
+                    action="CreateWorklog.jspa"
+                    class="aui dnd-attachment-support"
+                    id="log-work"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="log-work-submit"
+                                name="Log"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Log"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="/jira/browse/PIG-1"
+                                id="log-work-cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </main>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/secure/CreateWorklog.jspa"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.spec.ts
+++ b/src/actions/JiraSave.spec.ts
@@ -544,3 +544,70 @@ test("JIRA issue add worklog", () => {
 
     assert.isNotNull(actual);
 });
+
+test("JIRA issue add worklog, pop-up", () => {
+    const html = `
+<html class="mozilla" lang="en">
+    <head>
+        <title>Log Work: PIG-1</title>
+    </head>
+    <body
+        id="jira"
+        data-version="8.20.17"
+        data-aui-version="9.2.3-4dc984d9f"
+        >
+        <div id="content">
+        </div>
+        <div
+            id="log-work-dialog"
+            class="jira-dialog jira-dialog-core box-shadow jira-dialog-open popup-width-large jira-dialog-content-ready"
+            style="width: 810px; margin-left: -406px; margin-top: -358.5px"
+            >
+            <div class="jira-dialog-heading jira-dialog-core-heading">
+                <h2 title="Log Work: PIG-1">Log Work: PIG-1</h2>
+            </div>
+            <div class="jira-dialog-content jira-dialog-core-content">
+                <form
+                    action="CreateWorklog.jspa"
+                    class="aui dnd-attachment-support"
+                    id="log-work"
+                    method="post"
+                    >
+                    <div class="buttons-container form-footer">
+                        <div class="buttons">
+                            <input
+                                accesskey="s"
+                                class="aui-button"
+                                id="log-work-submit"
+                                name="Log"
+                                title="Press Alt+Shift+s to submit this form"
+                                type="submit"
+                                value="Log"
+                                resolved=""
+                                />
+                            <a
+                                accesskey="\`"
+                                class="aui-button aui-button-link cancel"
+                                href="/jira/browse/PIG-1"
+                                id="log-work-cancel"
+                                title="Press Alt+Shift+\` to cancel"
+                                resolved=""
+                                >
+                                Cancel
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </body>
+</html>
+`;
+
+    const actual = testFindSaveButton(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+
+    assert.isNotNull(actual);
+});

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -21,7 +21,7 @@ export class JiraSave implements Action {
         }
 
         const button: HTMLInputElement | null = doc.querySelector(
-            "input#issue-create-submit"
+            "input#issue-create-submit, input#edit-issue-submit"
         );
         return button;
     }

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -21,7 +21,7 @@ export class JiraSave implements Action {
         }
 
         const button: HTMLInputElement | null = doc.querySelector(
-            "input#issue-create-submit, input#edit-issue-submit"
+            "input#issue-create-submit, input#edit-issue-submit, input[name='edit-labels-submit']"
         );
         return button;
     }

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -1,0 +1,27 @@
+import { Action } from "../Action";
+
+export class JiraSave implements Action {
+    async perform(
+        doc: Document,
+        url: string,
+        e: KeyboardEvent
+    ): Promise<boolean> {
+        const form: HTMLFormElement | null = this.findSaveableForm(doc, url);
+        if (form) {
+            form.submit();
+            return true;
+        }
+        return false;
+    }
+
+    findSaveableForm(doc: Document, url: string): HTMLFormElement | null {
+        const body: HTMLBodyElement | null = doc.querySelector("body#jira");
+        if (!body) {
+            return null;
+        }
+
+        const form: HTMLFormElement | null =
+            doc.querySelector("form#issue-create");
+        return form;
+    }
+}

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -21,6 +21,7 @@ export class JiraSave implements Action {
         }
 
         const saveButtonSelectors = [
+            "input#create-issue-submit",
             "input#issue-create-submit",
             "input#edit-issue-submit",
             "input#issue-edit-submit",

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -20,8 +20,13 @@ export class JiraSave implements Action {
             return null;
         }
 
+        const saveButtonSelectors = [
+            "input#issue-create-submit",
+            "input#edit-issue-submit",
+            "input[name='edit-labels-submit']",
+        ];
         const button: HTMLInputElement | null = doc.querySelector(
-            "input#issue-create-submit, input#edit-issue-submit, input[name='edit-labels-submit']"
+            saveButtonSelectors.join(", ")
         );
         return button;
     }

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -25,6 +25,7 @@ export class JiraSave implements Action {
             "input#edit-issue-submit",
             "input[name='edit-labels-submit']",
             "input[name='Link'][type='submit'].aui-button",
+            "input#log-work-submit",
         ];
         const button: HTMLInputElement | null = doc.querySelector(
             saveButtonSelectors.join(", ")

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -24,6 +24,7 @@ export class JiraSave implements Action {
             "input#issue-create-submit",
             "input#edit-issue-submit",
             "input[name='edit-labels-submit']",
+            "input[name='Link'][type='submit'].aui-button",
         ];
         const button: HTMLInputElement | null = doc.querySelector(
             saveButtonSelectors.join(", ")

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -6,22 +6,23 @@ export class JiraSave implements Action {
         url: string,
         e: KeyboardEvent
     ): Promise<boolean> {
-        const form: HTMLFormElement | null = this.findSaveableForm(doc, url);
-        if (form) {
-            form.submit();
+        const button: HTMLInputElement | null = this.findSaveButton(doc, url);
+        if (button) {
+            button.click();
             return true;
         }
         return false;
     }
 
-    findSaveableForm(doc: Document, url: string): HTMLFormElement | null {
+    findSaveButton(doc: Document, url: string): HTMLInputElement | null {
         const body: HTMLBodyElement | null = doc.querySelector("body#jira");
         if (!body) {
             return null;
         }
 
-        const form: HTMLFormElement | null =
-            doc.querySelector("form#issue-create");
-        return form;
+        const button: HTMLInputElement | null = doc.querySelector(
+            "input#issue-create-submit"
+        );
+        return button;
     }
 }

--- a/src/actions/JiraSave.ts
+++ b/src/actions/JiraSave.ts
@@ -23,6 +23,7 @@ export class JiraSave implements Action {
         const saveButtonSelectors = [
             "input#issue-create-submit",
             "input#edit-issue-submit",
+            "input#issue-edit-submit",
             "input[name='edit-labels-submit']",
             "input[name='Link'][type='submit'].aui-button",
             "input#log-work-submit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { JenkinsConsole } from "./actions/JenkinsConsole";
 import { JenkinsCredentials } from "./actions/JenkinsCredentials";
 import { JenkinsDashboard } from "./actions/JenkinsDashboard";
 import { JiraLinkIssue } from "./actions/JiraLinkIssue";
+import { JiraSave } from "./actions/JiraSave";
 import { JenkinsNext } from "./actions/JenkinsNext";
 import { JenkinsPipelineSyntax } from "./actions/JenkinsPipelineSyntax";
 import { JenkinsPrevious } from "./actions/JenkinsPrevious";
@@ -76,6 +77,11 @@ const shortcuts : Map<string, Array<Action>> = new Map([
     [
         KeyboardShortcut.asString(false, false, false, "r"), [
             new JenkinsDashboard(),
+        ]
+    ],
+    [
+        KeyboardShortcut.asString(false, true, false, "s"), [
+            new JiraSave(),
         ]
     ],
     [

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,14 +96,12 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
     const url: string = window.location.href;
     // prettier-ignore
     if (
+        e.ctrlKey ||
+        e.altKey ||
         e.target &&
         (
-            e.ctrlKey ||
-            e.altKey ||
-            (
-                !(e.target instanceof HTMLInputElement) &&
-                !(e.target instanceof HTMLTextAreaElement)
-            )
+            !(e.target instanceof HTMLInputElement) &&
+            !(e.target instanceof HTMLTextAreaElement)
         )
     ) {
         const shortcutString = KeyboardShortcut.asString(

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -19,7 +19,7 @@ test("should parse a simple issue page", () => {
     <head>
         <title>[DO-8731] GitHub PR comment bodies are fully rendered - Jira</title>
     </head>
-    <body>
+    <body id="jira">
         <div id="page">
             <div id="content">
                 <div class="aui-page-panel">
@@ -53,7 +53,7 @@ test("issue page when coming from Confluence", () => {
     <head>
         <title>[DO-8731] GitHub PR comment bodies are fully rendered - Jira</title>
     </head>
-    <body>
+    <body id="jira">
         <div id="page">
             <div id="content">
                 <div class="aui-page-panel">
@@ -88,7 +88,7 @@ test("should parse an issue page hosted under a folder", () => {
         <title>[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA</title>
         <link rel="search" type="application/opensearchdescription+xml" href="/jira/osd.jsp" title="[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA">
     </head>
-    <body>
+    <body id="jira">
         <div id="page">
             <div id="content">
                 <div class="aui-page-panel">
@@ -123,7 +123,7 @@ test("should parse an issue page hosted under many folders", () => {
         <title>[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA</title>
         <link rel="search" type="application/opensearchdescription+xml" href="/jira/osd.jsp" title="[HTTPCLIENT-1763] Invalid 'expires' attribute - ASF JIRA">
     </head>
-    <body>
+    <body id="jira">
         <div id="page">
             <div id="content">
                 <div class="aui-page-panel">
@@ -157,7 +157,7 @@ test("should parse a title from a custom JIRA deployment", () => {
     <head>
         <title>[JENKINS-69135] Add a &quot;Versions to include&quot; field to the Global Library Cache feature - Jenkins Jira</title>
     </head>
-    <body>
+    <body id="jira">
         <div id="page">
             <div id="content">
                 <div class="aui-page-panel">

--- a/src/parsers/Jira.spec.ts
+++ b/src/parsers/Jira.spec.ts
@@ -47,6 +47,40 @@ test("should parse a simple issue page", () => {
     );
 });
 
+test("should parse a simple issue page w/query fragment", () => {
+    const html = `
+<html>
+    <head>
+        <title>[PIG-1] The Chicken contributed, the Pig committed - Jira</title>
+    </head>
+    <body id="jira">
+        <div id="page">
+            <div id="content">
+                <div class="aui-page-panel">
+                    <!-- etc., etc... -->
+                    <h1 id="summary-val">The Chicken contributed, the Pig committed</h1>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "http://localhost:2990/jira/browse/PIG-1#linkingmodule"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "http://localhost:2990/jira/browse/PIG-1"
+    );
+    assert.equal(
+        actual?.text,
+        "PIG-1: The Chicken contributed, the Pig committed"
+    );
+});
+
 test("issue page when coming from Confluence", () => {
     const html = `
 <html>

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -1,19 +1,23 @@
 import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
-
-const issueUrlRegex =
-    /https:\/\/(?<host>[^/]+)\/([^/]+\/)*browse\/(?<issueKey>[^?]+)(\?(?<rest>.+))?/;
+const issuePathRegex =
+    /browse\/(?<issueKey>[A-Z][A-Z0-9]+-\d+)/;
 export class Jira extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
-        const issueUrlMatch = url.match(issueUrlRegex);
-        if (!issueUrlMatch || !issueUrlMatch.groups) {
+        const u = new URL(url);
+        const path = u.pathname;
+        if (path.indexOf("browse/") == -1) {
             return null;
         }
-        const issueUrlGroups = issueUrlMatch.groups;
-        const issueKey = issueUrlGroups.issueKey;
+        const pathMatch = path.match(issuePathRegex);
+        if (!pathMatch || !pathMatch.groups) {
+            return null;
+        }
+        const pathGroups = pathMatch.groups;
+        const issueKey = pathGroups.issueKey;
         var linkText = `${issueKey}`;
 
-        const h1Element : HTMLElement | null = doc.querySelector("#summary-val");
+        const h1Element: HTMLElement | null = doc.querySelector("#summary-val");
         if (h1Element) {
             const summary = h1Element.textContent;
             if (summary) {

--- a/src/parsers/Jira.ts
+++ b/src/parsers/Jira.ts
@@ -25,14 +25,13 @@ export class Jira extends AbstractParser {
             }
         }
 
-        const confMacro : string = "?src=confmacro";
-        if (url.endsWith(confMacro)) {
-            url = url.substring(0, url.length - confMacro.length);
-        }
+        const cleanUrl = new URL(url);
+        cleanUrl.search = "";
+        cleanUrl.hash = "";
 
         const result: Link = {
             text: linkText,
-            destination: url,
+            destination: cleanUrl.toString(),
         };
         return result;
     }


### PR DESCRIPTION
I am used to `Alt+S` for saving in JIRA, but that doesn't work in browsers whose names start with "F" and end with "irefox" because they have the "History" menu with an accelerator on the `s`, meaning it's what pops open when hitting `Alt+S`.  This fixes this grave mistake in most places with a "save" button, plus some last-minute enhancements around copying JIRA URLs.