### PR TITLE
feat: enhance JenkinsBuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@types/node": "^16.11.10",
                 "@types/tampermonkey": "^4.0.5",
                 "@types/webpack": "^5.28.0",
+                "happy-dom": "^9.20.3",
                 "jsdom": "^19.0.0",
                 "node": "^16.19.0",
                 "package-json-io": "1.0.0",
@@ -770,6 +771,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true
+        },
         "node_modules/cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -896,6 +903,18 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/envinfo": {
@@ -1164,6 +1183,20 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
+        },
+        "node_modules/happy-dom": {
+            "version": "9.20.3",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-9.20.3.tgz",
+            "integrity": "sha512-eBsgauT435fXFvQDNcmm5QbGtYzxEzOaX35Ia+h6yP/wwa4xSWZh1CfP+mGby8Hk6Xu59mTkpyf72rUXHNxY7A==",
+            "dev": true,
+            "dependencies": {
+                "css.escape": "^1.5.1",
+                "entities": "^4.5.0",
+                "iconv-lite": "^0.6.3",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^2.0.0",
+                "whatwg-mimetype": "^3.0.0"
+            }
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -3691,6 +3724,12 @@
                 "which": "^2.0.1"
             }
         },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true
+        },
         "cssom": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -3791,6 +3830,12 @@
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
             }
+        },
+        "entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true
         },
         "envinfo": {
             "version": "7.8.1",
@@ -3989,6 +4034,20 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
+        },
+        "happy-dom": {
+            "version": "9.20.3",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-9.20.3.tgz",
+            "integrity": "sha512-eBsgauT435fXFvQDNcmm5QbGtYzxEzOaX35Ia+h6yP/wwa4xSWZh1CfP+mGby8Hk6Xu59mTkpyf72rUXHNxY7A==",
+            "dev": true,
+            "requires": {
+                "css.escape": "^1.5.1",
+                "entities": "^4.5.0",
+                "iconv-lite": "^0.6.3",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^2.0.0",
+                "whatwg-mimetype": "^3.0.0"
+            }
         },
         "has": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@types/node": "^16.11.10",
         "@types/tampermonkey": "^4.0.5",
         "@types/webpack": "^5.28.0",
+        "happy-dom": "^9.20.3",
         "jsdom": "^19.0.0",
         "node": "^16.19.0",
         "package-json-io": "1.0.0",

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -2,7 +2,9 @@ import { assert, test } from "vitest";
 import { JenkinsBuild } from "./JenkinsBuild";
 import { JSDOM } from "jsdom";
 
-function testNavigate(html: string, url: string): string | null {
+// @vitest-environment happy-dom
+
+function testNavigate(html: string, url: string): Request | null {
     const dom: JSDOM = new JSDOM(html);
     const document: Document = dom.window.document;
     const cut = new JenkinsBuild();
@@ -99,7 +101,7 @@ test("job page 2.361.4", () => {
     );
 
     assert.equal(
-        actual,
+        actual?.url,
         "http://localhost:8080/job/Project/job/Repository/job/Branch/build?delay=0sec"
     );
 });
@@ -169,7 +171,7 @@ test("run page", () => {
     );
 
     assert.equal(
-        actual,
+        actual?.url,
         "http://localhost:8080/job/Project/job/Repository/job/Branch/build?delay=0sec"
     );
 });
@@ -239,7 +241,7 @@ test("run console page", () => {
     );
 
     assert.equal(
-        actual,
+        actual?.url,
         "http://localhost:8080/job/Project/job/Repository/job/Branch/build?delay=0sec"
     );
 });

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -349,3 +349,45 @@ test("createBuildableItem: run queued and stuck", async () => {
     assert.equal(actual.buildable, true);
     assert.equal(actual.stuck, true);
 });
+
+test("createBuildableItem: run aborted", async () => {
+    const json = `{
+    "_class": "hudson.model.Queue$LeftItem",
+    "actions": [
+        {
+            "_class": "hudson.model.CauseAction",
+            "causes": [
+                {
+                    "_class": "hudson.model.Cause$UserIdCause",
+                    "shortDescription": "Started by user Olivier Admin Dagenais",
+                    "userId": "admin",
+                    "userName": "Olivier Admin Dagenais"
+                }
+            ]
+        }
+    ],
+    "blocked": false,
+    "buildable": false,
+    "id": 18,
+    "inQueueSince": 1684891412992,
+    "params": "",
+    "stuck": false,
+    "task": {
+        "_class": "hudson.model.FreeStyleProject",
+        "name": "Non Parameterized Branch",
+        "url": "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/",
+        "color": "blue"
+    },
+    "url": "queue/item/18/",
+    "why": null,
+    "cancelled": true,
+    "executable": null
+}`;
+
+    const actual = await testCreateBuildableItem(json);
+
+    assert.equal(actual.blocked, false);
+    assert.equal(actual.buildable, false);
+    assert.equal(actual.stuck, false);
+    assert.equal(actual.cancelled, true);
+});

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -17,7 +17,10 @@ function testNavigate(html: string, url: string): Request | null {
 test("job page 2.361.4", () => {
     const html = `
 <html>
-    <head>
+    <head
+        data-crumb-header="Jenkins-Crumb"
+        data-crumb-value="c928c875447b927341155d6b0f64ab0720e27f9fd2972c04f41dd48d4aa9e4d3"
+        >
         <title>Branch [Project » Repository] [Jenkins]</title>
     </head>
     <body
@@ -110,7 +113,10 @@ test("job page 2.361.4", () => {
 test("run page", () => {
     const html = `
 <html>
-    <head>
+    <head
+        data-crumb-header="Jenkins-Crumb"
+        data-crumb-value="c928c875447b927341155d6b0f64ab0720e27f9fd2972c04f41dd48d4aa9e4d3"
+        >
         <title>Project » Repository » Branch #1 [Jenkins]</title>
     </head>
     <body
@@ -180,7 +186,10 @@ test("run page", () => {
 test("run console page", () => {
     const html = `
 <html>
-    <head>
+    <head
+        data-crumb-header="Jenkins-Crumb"
+        data-crumb-value="c928c875447b927341155d6b0f64ab0720e27f9fd2972c04f41dd48d4aa9e4d3"
+        >
         <title>Project » Repository » Branch #1 Console [Jenkins]</title>
     </head>
     <body
@@ -250,7 +259,10 @@ test("run console page", () => {
 test("dashboard page", () => {
     const html = `
 <html>
-    <head>
+    <head
+        data-crumb-header="Jenkins-Crumb"
+        data-crumb-value="c928c875447b927341155d6b0f64ab0720e27f9fd2972c04f41dd48d4aa9e4d3"
+        >
         <title>Branch [Project » Repository] [Jenkins]</title>
     </head>
     <body

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -278,3 +278,54 @@ test("dashboard page", () => {
 
     assert.equal(actual, null);
 });
+
+test("createBuildableItem: run queued and stuck", async () => {
+    const json = `{
+    "_class": "hudson.model.Queue$BuildableItem",
+    "actions": [
+        {
+            "_class": "hudson.model.CauseAction",
+            "causes": [
+                {
+                    "_class": "hudson.model.Cause$UserIdCause",
+                    "shortDescription": "Started by user Olivier Admin Dagenais",
+                    "userId": "admin",
+                    "userName": "Olivier Admin Dagenais"
+                }
+            ]
+        }
+    ],
+    "blocked": false,
+    "buildable": true,
+    "id": 18,
+    "inQueueSince": 1684891412992,
+    "params": "",
+    "stuck": true,
+    "task": {
+        "_class": "hudson.model.FreeStyleProject",
+        "name": "Non Parameterized Branch",
+        "url": "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/",
+        "color": "blue"
+    },
+    "url": "queue/item/18/",
+    "why": "'Jenkins' doesn't have label 'chicken'",
+    "buildableStartMilliseconds": 1684891412993,
+    "pending": false
+}`;
+    const body: XMLHttpRequestBodyInit = json;
+    const responseInit: ResponseInit = {
+        headers: [
+            ["Content-Type", "application/json;charset=utf-8"],
+            ["X-Jenkins", "2.361.4"],
+        ],
+        status: 200,
+        statusText: "OK",
+    };
+    const response: Response = new Response(body, responseInit);
+
+    const actual = await JenkinsBuild.createBuildableItem(response);
+
+    assert.equal(actual.blocked, false);
+    assert.equal(actual.buildable, true);
+    assert.equal(actual.stuck, true);
+});

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -439,6 +439,14 @@ test("createBuildableItem: run completed", async () => {
     assert.equal(actual.buildable, false);
     assert.equal(actual.stuck, false);
     assert.equal(actual.cancelled, false);
-    assert.isNotNull(actual.executable);
-    assert.equal(actual.executable.url, "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/11/");
+    if (actual.executable) {
+        assert.equal(
+            actual.executable.url,
+            "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/11/"
+        );
+    } else {
+        assert.fail(
+            "actual.executable was null or undefined: " + actual.executable
+        );
+    }
 });

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -1,4 +1,5 @@
 import { assert, test } from "vitest";
+import { BuildableItem } from "./JenkinsBuild";
 import { JenkinsBuild } from "./JenkinsBuild";
 import { JSDOM } from "jsdom";
 
@@ -279,6 +280,23 @@ test("dashboard page", () => {
     assert.equal(actual, null);
 });
 
+async function testCreateBuildableItem(json: string): Promise<BuildableItem> {
+    const body: XMLHttpRequestBodyInit = json;
+    const responseInit: ResponseInit = {
+        headers: [
+            ["Content-Type", "application/json;charset=utf-8"],
+            ["X-Jenkins", "2.361.4"],
+        ],
+        status: 200,
+        statusText: "OK",
+    };
+    const response: Response = new Response(body, responseInit);
+
+    const actual = await JenkinsBuild.createBuildableItem(response);
+
+    return actual;
+}
+
 test("createBuildableItem: run queued and stuck", async () => {
     const json = `{
     "_class": "hudson.model.Queue$BuildableItem",
@@ -312,18 +330,8 @@ test("createBuildableItem: run queued and stuck", async () => {
     "buildableStartMilliseconds": 1684891412993,
     "pending": false
 }`;
-    const body: XMLHttpRequestBodyInit = json;
-    const responseInit: ResponseInit = {
-        headers: [
-            ["Content-Type", "application/json;charset=utf-8"],
-            ["X-Jenkins", "2.361.4"],
-        ],
-        status: 200,
-        statusText: "OK",
-    };
-    const response: Response = new Response(body, responseInit);
 
-    const actual = await JenkinsBuild.createBuildableItem(response);
+    const actual = await testCreateBuildableItem(json);
 
     assert.equal(actual.blocked, false);
     assert.equal(actual.buildable, true);

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -349,6 +349,7 @@ test("createBuildableItem: run queued and stuck", async () => {
     assert.equal(actual.buildable, true);
     assert.equal(actual.stuck, true);
     assert.equal(actual.cancelled, false);
+    assert.isNull(actual.executable);
 });
 
 test("createBuildableItem: run aborted", async () => {
@@ -391,4 +392,53 @@ test("createBuildableItem: run aborted", async () => {
     assert.equal(actual.buildable, false);
     assert.equal(actual.stuck, false);
     assert.equal(actual.cancelled, true);
+    assert.isNull(actual.executable);
+});
+
+test("createBuildableItem: run completed", async () => {
+    const json = `{
+    "_class": "hudson.model.Queue$LeftItem",
+    "actions": [
+        {
+            "_class": "hudson.model.CauseAction",
+            "causes": [
+                {
+                    "_class": "hudson.model.Cause$UserIdCause",
+                    "shortDescription": "Started by user Olivier Admin Dagenais",
+                    "userId": "admin",
+                    "userName": "Olivier Admin Dagenais"
+                }
+            ]
+        }
+    ],
+    "blocked": false,
+    "buildable": false,
+    "id": 20,
+    "inQueueSince": 1684891664768,
+    "params": "",
+    "stuck": false,
+    "task": {
+        "_class": "hudson.model.FreeStyleProject",
+        "name": "Non Parameterized Branch",
+        "url": "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/",
+        "color": "blue"
+    },
+    "url": "queue/item/20/",
+    "why": null,
+    "cancelled": false,
+    "executable": {
+        "_class": "hudson.model.FreeStyleBuild",
+        "number": 11,
+        "url": "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/11/"
+    }
+}`;
+
+    const actual = await testCreateBuildableItem(json);
+
+    assert.equal(actual.blocked, false);
+    assert.equal(actual.buildable, false);
+    assert.equal(actual.stuck, false);
+    assert.equal(actual.cancelled, false);
+    assert.isNotNull(actual.executable);
+    assert.equal(actual.executable.url, "http://localhost:8080/job/Project/job/Repository/job/Non%20Parameterized%20Branch/11/");
 });

--- a/src/actions/JenkinsBuild.spec.ts
+++ b/src/actions/JenkinsBuild.spec.ts
@@ -348,6 +348,7 @@ test("createBuildableItem: run queued and stuck", async () => {
     assert.equal(actual.blocked, false);
     assert.equal(actual.buildable, true);
     assert.equal(actual.stuck, true);
+    assert.equal(actual.cancelled, false);
 });
 
 test("createBuildableItem: run aborted", async () => {

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -30,7 +30,7 @@ export class JenkinsBuild implements Action {
             blocked: map.blocked,
             buildable: map.buildable,
             stuck: map.stuck,
-            cancelled: map.cancelled,
+            cancelled: map.cancelled || false,
         };
         return result;
     }

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -1,8 +1,21 @@
 import { JenkinsHelpers } from "../JenkinsHelpers";
-import { GoToAction } from "./GoToAction";
+import { Action } from "../Action";
 
-export class JenkinsBuild extends GoToAction {
-    navigate(doc: Document, url: string): string | null {
+export class JenkinsBuild implements Action {
+    async perform(
+        doc: Document,
+        url: string,
+        e: KeyboardEvent
+    ): Promise<boolean> {
+        const request: Request | null = this.navigate(doc, url);
+        if (request) {
+            window.location.href = request.url;
+            return true;
+        }
+        return false;
+    }
+
+    navigate(doc: Document, url: string): Request | null {
         const bodyElement = JenkinsHelpers.getBodyElement(doc);
         if (!bodyElement) {
             return null;
@@ -20,11 +33,12 @@ export class JenkinsBuild extends GoToAction {
             if (anchor) {
                 const path = anchor.getAttribute("href");
                 if (path) {
-                    return JenkinsHelpers.buildUrl(
+                    const destinationUrl = JenkinsHelpers.buildUrl(
                         url,
                         path + "build",
                         "delay=0sec"
                     );
+                    return new Request(destinationUrl);
                 }
             }
         } else {
@@ -36,11 +50,12 @@ export class JenkinsBuild extends GoToAction {
                     if (href) {
                         const hrefParts = JenkinsHelpers.splitPath(href);
                         if ("job" == hrefParts[hrefParts.length - 2]) {
-                            return JenkinsHelpers.buildUrl(
+                            const destinationUrl = JenkinsHelpers.buildUrl(
                                 url,
                                 href + "build",
                                 "delay=0sec"
                             );
+                            return new Request(destinationUrl);
                         }
                     }
                 }

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -13,9 +13,9 @@ export class JenkinsBuild implements Action {
         url: string,
         e: KeyboardEvent
     ): Promise<boolean> {
-        const request: Request | null = this.navigate(doc, url);
+        const request = this.navigate(doc, url);
         if (request) {
-            window.location.href = request.url;
+            setTimeout(() => this.queueRun(request), 1 /*ms*/);
             return true;
         }
         return false;
@@ -81,5 +81,9 @@ export class JenkinsBuild implements Action {
         }
 
         return null;
+    }
+
+    queueRun(request: Request) {
+        window.location.href = request.url;
     }
 }

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -1,11 +1,17 @@
 import { JenkinsHelpers } from "../JenkinsHelpers";
 import { Action } from "../Action";
 
+export interface Executable {
+    number?: number;
+    url?: string;
+}
+
 export interface BuildableItem {
     blocked?: boolean;
     buildable?: boolean;
     stuck?: boolean;
     cancelled?: boolean;
+    executable?: Executable;
 }
 
 export class JenkinsBuild implements Action {
@@ -31,6 +37,7 @@ export class JenkinsBuild implements Action {
             buildable: map.buildable,
             stuck: map.stuck,
             cancelled: map.cancelled || false,
+            executable: map.executable || null,
         };
         return result;
     }

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -39,6 +39,17 @@ export class JenkinsBuild implements Action {
             return null;
         }
 
+        const headElement = doc.querySelector(
+            "head[data-crumb-header][data-crumb-value]"
+        );
+        if (!headElement) {
+            return null;
+        }
+        const headerName = headElement.getAttribute("data-crumb-header");
+        const headerValue = headElement.getAttribute("data-crumb-value");
+        if (!headerName || !headerValue) {
+            return null;
+        }
         /* <a> elements with an href ending in "/build?delay=0sec" */
         const linkSelector = "a[href$='/build?delay=0sec']";
         const crumbSelector =

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -1,7 +1,7 @@
 import { JenkinsHelpers } from "../JenkinsHelpers";
 import { Action } from "../Action";
 
-interface BuildableItem {
+export interface BuildableItem {
     blocked?: boolean;
     buildable?: boolean;
     stuck?: boolean;

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -5,6 +5,7 @@ export interface BuildableItem {
     blocked?: boolean;
     buildable?: boolean;
     stuck?: boolean;
+    cancelled?: boolean;
 }
 
 export class JenkinsBuild implements Action {
@@ -29,6 +30,7 @@ export class JenkinsBuild implements Action {
             blocked: map.blocked,
             buildable: map.buildable,
             stuck: map.stuck,
+            cancelled: map.cancelled,
         };
         return result;
     }

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -1,6 +1,12 @@
 import { JenkinsHelpers } from "../JenkinsHelpers";
 import { Action } from "../Action";
 
+interface BuildableItem {
+    blocked?: boolean;
+    buildable?: boolean;
+    stuck?: boolean;
+}
+
 export class JenkinsBuild implements Action {
     async perform(
         doc: Document,
@@ -13,6 +19,18 @@ export class JenkinsBuild implements Action {
             return true;
         }
         return false;
+    }
+
+    static async createBuildableItem(
+        response: Response
+    ): Promise<BuildableItem> {
+        const map: any = await response.json();
+        const result: BuildableItem = {
+            blocked: map.blocked,
+            buildable: map.buildable,
+            stuck: map.stuck,
+        };
+        return result;
     }
 
     navigate(doc: Document, url: string): Request | null {

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -149,9 +149,10 @@ export class JenkinsBuild implements Action {
                 // TODO: we could also do a capped exponential backoff: 1, 2, 4, 4, 4, 4
                 await JenkinsBuild.sleep(1000);
             }
+        } else if (400 == response.status) {
+            // build is parameterized, try again with HTTP GET
+            window.location.href = request.url;
         }
-        // TODO: if the response isn't HTTP 201 (Created),
-        // then we need to provide parameters?
     }
 
     // https://stackoverflow.com/a/47092642/98903

--- a/src/actions/JenkinsBuild.ts
+++ b/src/actions/JenkinsBuild.ts
@@ -33,9 +33,9 @@ export class JenkinsBuild implements Action {
     ): Promise<BuildableItem> {
         const map: any = await response.json();
         const result: BuildableItem = {
-            blocked: map.blocked,
-            buildable: map.buildable,
-            stuck: map.stuck,
+            blocked: map.blocked || false,
+            buildable: map.buildable || false,
+            stuck: map.stuck || false,
             cancelled: map.cancelled || false,
             executable: map.executable || null,
         };


### PR DESCRIPTION
For jobs that take no parameters, hitting `b` will now not only queue a run (by POSTing with the crumb) but also automatically navigate to that run's `consoleFull` link to track its progress (as soon as it's available), while falling back to retrying the request with GET if it turns out the job defined some parameters.

It would be nicer with visual feedback, but this will do for now.