### PR TITLE
doc: fix path to branches in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Tampermonkey userscript to copy nice-looking URLs to the clipboard.
 
 1. First, you need to install the Tampermonkey extension for your browser, which can be found at: <https://www.tampermonkey.net/>
 1. If you are using Firefox, follow the one-time configuration in the sub-section below.
-1. You have to decide whether you want to always track the latest version (known as the `live` branch) or one of the release branches (which start with `release/`). Go to <https://github.com/olivierdagenais/tampermonkey-copy-url/branches> and make your choice.
+1. You have to decide whether you want to always track the latest version (known as the `live` branch) or one of the release branches (which start with `release/`). Go to <https://github.com/olivierdagenais/tampermonkey-copy-url/branches/all> and make your choice.
 1. Navigate to the `userscript/index.user.js` file.
 1. Activate the **Raw** link. Tampermonkley should detect that a UserScript is there and prompt you to install it.
 1. Tampermonkey will check for updates and prompt you to upgrade when a new version is released.


### PR DESCRIPTION
Without this, it's not clear what branches are available to others since I see them all but non-contributors wouldn't.