### PR TITLE
feat: prefer Confluence's "Tiny link" (shortlink)

### DIFF
--- a/src/parsers/Confluence.spec.ts
+++ b/src/parsers/Confluence.spec.ts
@@ -61,6 +61,8 @@ test("should parse a page about Confluence in Confluence", () => {
         </title>
         <meta name="ajs-page-title" content="Create and Edit Pages">
         <meta name="ajs-latest-published-page-title" content="Create and Edit Pages">
+        <link rel="canonical" href="https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages">
+        <link rel="shortlink" href="https://confluence.columbia.edu/confluence/x/14KCCg">
         <meta name="wikilink" content="[CONFDOCS:Create and Edit Pages]">
     </head>
     <body
@@ -87,7 +89,7 @@ test("should parse a page about Confluence in Confluence", () => {
     assert.notEqual(actual, null);
     assert.equal(
         actual?.destination,
-        "https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages"
+        "https://confluence.columbia.edu/confluence/x/14KCCg"
     );
     assert.equal(actual?.text, "Create and Edit Pages");
 });

--- a/src/parsers/Confluence.ts
+++ b/src/parsers/Confluence.ts
@@ -10,6 +10,13 @@ export class Confluence extends AbstractParser {
             return null;
         }
 
+        const shortlinkElement: HTMLLinkElement | null = doc.querySelector(
+            "html > head > link[rel=shortlink]"
+        );
+        if (shortlinkElement) {
+            url = shortlinkElement.href;
+        }
+
         const titleElement: HTMLElement | null =
             doc.querySelector("#title-text");
         if (!titleElement || !titleElement.textContent) {


### PR DESCRIPTION
Implements #46.

# Manual testing

## GIVEN

I temporarily configured my browser with a build of this branch

## WHEN

I visited https://confluence.columbia.edu/confluence/display/CONFDOCS/Create+and+Edit+Pages (which is running **Confluence 7.19.18**) and activated the "Copy as Markdown" action.

## THEN

The clipboard contained:

```markdown
[Create and Edit Pages](https://confluence.columbia.edu/confluence/x/14KCCg)
```

## AND

Visiting https://confluence.columbia.edu/confluence/x/14KCCg I am taken to the page I started with.

Mission accomplished!