### PR TITLE
feat: support FR-CA keyboard on Windows 10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,12 @@ const shortcuts : Map<string, Array<Action>> = new Map([
         ]
     ],
     [
+        // Ctrl+Alt+o with FR-CA keyboard on Windows 10 yields a "Section Sign"
+        KeyboardShortcut.asString(false, false, false, "\u00a7"), [
+            new CopyUrl(statusPopup, new Textile()),
+        ]
+    ],
+    [
         KeyboardShortcut.asString(false, false, false, "p"), [
             new JenkinsPipelineSyntax(),
             new JenkinsPrevious(),
@@ -71,6 +77,12 @@ const shortcuts : Map<string, Array<Action>> = new Map([
     ],
     [
         KeyboardShortcut.asString(true, true, false, "p"), [
+            new CopyUrl(statusPopup, new Html()),
+        ]
+    ],
+    [
+        // Ctrl+Alt+p with FR-CA keyboard on Windows 10 yields a "Pilcrow Sign"
+        KeyboardShortcut.asString(false, false, false, "\u00b6"), [
             new CopyUrl(statusPopup, new Html()),
         ]
     ],


### PR DESCRIPTION
I occasionally use the "French (Canada) Canadian French keyboard" layout on Windows 10 computers:
![image](https://github.com/olivierdagenais/tampermonkey-copy-url/assets/297515/537451e2-b46d-47d1-9ba9-de3903a41cb2)

But when I try to copy URLs in Textile or HTML format, nothing happens. The browser never sees that `Ctrl` & `Alt` are held when the third key is `o` or `p`; it just thinks I have these characters directly on my keyboard.  The solution is to accept those keys as shortcuts directly.  The difficulty is the compiler doesn't seem to handle UTF-8 so I had to use the `\u####` notation.

Fixes #41 

# Manual testing

## GIVEN

I have temporarily configured my browser with the output of `./docker_node npm run build` AND I go to the page https://github.com/olivierdagenais/tampermonkey-copy-url/issues/41

## WHEN

I hit `Ctrl+Alt+o` while in FR-CA mode.

## THEN

I get the Textile version copied to my clipboard:

```textile
[olivierdagenais/tampermonkey-copy-url#41: French Canadian keyboard sends special characters for some key-combinations|https://github.com/olivierdagenais/tampermonkey-copy-url/issues/41]
```

## WHEN

I hit `Ctrl+Alt+p` while in FR-CA mode.

## THEN

I get the HTML version copied to my clipboard:

```html
<html><head></head><body><a href="https://github.com/olivierdagenais/tampermonkey-copy-url/issues/41">olivierdagenais/tampermonkey-copy-url#41: French Canadian keyboard sends special characters for some key-combinations</a></body></html>
```

Mission accomplished!