### PR TITLE
feat: set focus to Bitbucket codesearch textbox

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,30 @@ async function handleKeydown(this: Window, e: KeyboardEvent) {
     }
 }
 
+async function handleBitbucketSearchLoaded(
+    mutations: MutationRecord[],
+    observer: MutationObserver
+) {
+    if (bitbucketSearchDiv) {
+        const searchBox: HTMLInputElement | null =
+            bitbucketSearchDiv.querySelector(
+                "form#search-form input.search-query"
+            );
+        if (searchBox) {
+            observer.disconnect();
+            searchBox.focus({ preventScroll: false });
+        }
+    } else {
+        observer.disconnect();
+    }
+}
+const codeSearchObserver = new MutationObserver(handleBitbucketSearchLoaded);
+const codeSearchObserverConfig: MutationObserverInit = {
+    subtree: true,
+    childList: true,
+};
+var bitbucketSearchDiv: HTMLDivElement | null;
+
 async function main(): Promise<void> {
     var doc = window.document;
     const styleAttribute = doc.createAttribute("style");
@@ -157,11 +181,19 @@ async function main(): Promise<void> {
     doc.body.appendChild(statusPopup);
 
     const jiraBody = doc.querySelector("body#jira[data-version]");
+    bitbucketSearchDiv = doc.querySelector(
+        "body.bitbucket-theme div#codesearch"
+    );
     if (jiraBody) {
         const anchor = jiraBody.querySelector("a#home_link[accesskey=d]");
         if (anchor) {
             anchor.removeAttribute("accesskey");
         }
+    } else if (bitbucketSearchDiv) {
+        codeSearchObserver.observe(
+            bitbucketSearchDiv,
+            codeSearchObserverConfig
+        );
     }
 
     window.addEventListener("keydown", handleKeydown);


### PR DESCRIPTION
I usually operate Bitbucket's search via a smart/parameterized bookmark, allowing me to type something like `b parse` in my browser's address bar and that gets converted into `http://localhost:7990/bitbucket/plugins/servlet/search?q=parse`

The problem is the way the page loads, the focus is by default to the left of the logo and the first tab stop is to `#content` and that appends `#content` to the URL which triggers another search.  You could also keep tabbing 8 or 9 more times, but this PR makes it such that the textbox gets focus as soon as it loads.

This makes it easy to not only refine the query but also to TAB to the results, allowing keyboard-based scrolling.

Tested with Bitbucket DC versions 7.21.10 and 8.9.9.

Fixes #48.