### PR TITLE
fix: home/end keys in Bitbucket DC's CodeMirror-based editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "tampermonkey-copy-url",
             "version": "1.0.0",
             "license": "MIT",
+            "dependencies": {
+                "@types/codemirror": "^5.60.15"
+            },
             "devDependencies": {
                 "@types/jsdom": "^16.2.14",
                 "@types/node": "^16.11.10",
@@ -179,6 +182,14 @@
                 "@types/chai": "*"
             }
         },
+        "node_modules/@types/codemirror": {
+            "version": "5.60.15",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+            "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
+            "dependencies": {
+                "@types/tern": "*"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.21.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
@@ -202,8 +213,7 @@
         "node_modules/@types/estree": {
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "dev": true
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "node_modules/@types/jsdom": {
             "version": "16.2.14",
@@ -239,6 +249,14 @@
             "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
             "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
             "dev": true
+        },
+        "node_modules/@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.1",
@@ -3253,6 +3271,14 @@
                 "@types/chai": "*"
             }
         },
+        "@types/codemirror": {
+            "version": "5.60.15",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+            "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
+            "requires": {
+                "@types/tern": "*"
+            }
+        },
         "@types/eslint": {
             "version": "8.21.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
@@ -3276,8 +3302,7 @@
         "@types/estree": {
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
-            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "dev": true
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
         },
         "@types/jsdom": {
             "version": "16.2.14",
@@ -3313,6 +3338,14 @@
             "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
             "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
             "dev": true
+        },
+        "@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "requires": {
+                "@types/estree": "*"
+            }
         },
         "@types/tough-cookie": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
         ],
         "exclude": [],
         "resources": []
+    },
+    "dependencies": {
+        "@types/codemirror": "^5.60.15"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,19 +181,20 @@ async function main(): Promise<void> {
     doc.body.appendChild(statusPopup);
 
     const jiraBody = doc.querySelector("body#jira[data-version]");
-    bitbucketSearchDiv = doc.querySelector(
-        "body.bitbucket-theme div#codesearch"
-    );
+    const bitbucketBody = doc.querySelector("body.bitbucket-theme");
     if (jiraBody) {
         const anchor = jiraBody.querySelector("a#home_link[accesskey=d]");
         if (anchor) {
             anchor.removeAttribute("accesskey");
         }
-    } else if (bitbucketSearchDiv) {
-        codeSearchObserver.observe(
-            bitbucketSearchDiv,
-            codeSearchObserverConfig
-        );
+    } else if (bitbucketBody) {
+        bitbucketSearchDiv = bitbucketBody.querySelector("div#codesearch");
+        if (bitbucketSearchDiv) {
+            codeSearchObserver.observe(
+                bitbucketSearchDiv,
+                codeSearchObserverConfig
+            );
+        }
     }
 
     window.addEventListener("keydown", handleKeydown);


### PR DESCRIPTION
Fixes #51.

# Manual testing

## GIVEN

A computer with access to Bitbucket v8.9.9 and running Firefox, Tampermonkey and the `index.user.js` file generated by the changes in this pull request.

## WHEN

I give focus to a CodeMirror-based editor (such as creating a pull request, editing a pull request description or creating/modifying a pull request comment) and I activate the Home and End keys.

## THEN

The cursor jumps to the home and end of the current line, even if it is a very long line wrapped across more than one visible line.  In other words, the cursor is no longer taken to the very beginning or the very end of the wrapped line.

## NOTES

There are still a few edge cases with "arrow up" when the cursor is on a longer virtual line than the one above it or when we're at or around the line-breaking character (likely based on the sticky value), but Home and End appear to function as expected, which was the biggest problem to fix.

Mission accomplished!