### PR TITLE
fix: pull request titles in Bitbucket DC 8.19.6

### DIFF
--- a/src/parsers/Bitbucket.spec.ts
+++ b/src/parsers/Bitbucket.spec.ts
@@ -77,6 +77,36 @@ test("should parse a simple Stash pull request page under a folder", () => {
     );
 });
 
+test("parseLink when Bitbucket DC 8.19.6", () => {
+    const html = `
+<html>
+    <head>
+        <title>Pull Request #4: DO-8731: fix: sanitize GitHub PR comment bodies - Stash</title>
+    </head>
+    <body>
+        <!-- etc.. -->
+        <span class="pull-request-title pull-request-header-title">
+            <h2>DO-8731: fix: sanitize GitHub PR comment bodies</h2>
+        </span>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://bitbucket.example.com/bitbucket/projects/TP/repos/jf_agent/pull-requests/4/overview"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://bitbucket.example.com/bitbucket/projects/TP/repos/jf_agent/pull-requests/4/overview"
+    );
+    assert.equal(
+        actual?.text,
+        "TP/jf_agent#4: DO-8731: fix: sanitize GitHub PR comment bodies"
+    );
+});
+
 test("PR without https", () => {
     const html = `
 <html>

--- a/src/parsers/Bitbucket.ts
+++ b/src/parsers/Bitbucket.ts
@@ -178,9 +178,11 @@ export class Bitbucket extends AbstractParser {
         const prId = prUrlGroups.prId;
         const extra = prUrlGroups.extra;
 
-        const h2Element = doc.querySelector(
-            "html > body h2.pull-request-title"
-        );
+        const h2Selectors = [
+            "html > body h2.pull-request-title",
+            "html > body span.pull-request-title > h2",
+        ];
+        const h2Element = doc.querySelector(h2Selectors.join(", "));
         if (!h2Element) {
             return null;
         }


### PR DESCRIPTION
Sometime between versions 8.9.9 and 8.19.6, the pull request's title changed slightly, breaking pull request links.

Fixes #68.

Tested using version 8.19.6 via the Atlas SDK.