### PR TITLE
fix: console and next run actions in Jenkins with new build history widget (2.463+)

### DIFF
--- a/src/JenkinsHelpers.spec.ts
+++ b/src/JenkinsHelpers.spec.ts
@@ -1,5 +1,88 @@
 import { assert, test } from "vitest";
+import { JSDOM } from "jsdom";
 import { JenkinsHelpers } from "./JenkinsHelpers";
+
+function getBodyElement(html: string): HTMLElement {
+    const dom: JSDOM = new JSDOM(html);
+    const document: Document = dom.window.document;
+    const result = JenkinsHelpers.getBodyElement(document);
+    if (!result) {
+        throw new Error("Invalid HTML");
+    }
+    return result;
+}
+
+test("getMostRecentRunSelector at 2.387.1", () => {
+    const html = `
+<html>
+    <head>
+        <title>Branch [Project » Repository] [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.387.1"
+        data-version="2.387.1"
+        >
+    </body>
+</html>
+`;
+    const bodyElement = getBodyElement(html);
+
+    const actual = JenkinsHelpers.getMostRecentRunSelector(bodyElement);
+
+    assert.equal(actual, "tr.build-row a.build-link");
+});
+
+test("getMostRecentRunSelector at 2.463", () => {
+    const html = `
+<html>
+    <head>
+        <title>Branch [Project » Repository] [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.463"
+        data-version="2.463"
+        >
+    </body>
+</html>
+`;
+    const bodyElement = getBodyElement(html);
+
+    const actual = JenkinsHelpers.getMostRecentRunSelector(bodyElement);
+
+    assert.equal(
+        actual,
+        "#jenkins-build-history .app-builds-container__item__inner__link"
+    );
+});
+
+test("getMostRecentRunSelector at 2.479.2", () => {
+    const html = `
+<html>
+    <head>
+        <title>Branch [Project » Repository] [Jenkins]</title>
+    </head>
+    <body
+        data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+        id="jenkins"
+        class="yui-skin-sam two-column jenkins-2.479.2"
+        data-version="2.479.2"
+        >
+    </body>
+</html>
+`;
+    const bodyElement = getBodyElement(html);
+
+    const actual = JenkinsHelpers.getMostRecentRunSelector(bodyElement);
+
+    assert.equal(
+        actual,
+        "#jenkins-build-history .app-builds-container__item__inner__link"
+    );
+});
 
 test("splitUrlPath with deep URL", () => {
     const input =

--- a/src/JenkinsHelpers.ts
+++ b/src/JenkinsHelpers.ts
@@ -1,3 +1,7 @@
+import { SemVer } from "./SemVer";
+
+const jenkins2_463 = SemVer.parse("2.463");
+
 export class JenkinsHelpers {
     static buildUrl(
         urlString: string,
@@ -28,6 +32,20 @@ export class JenkinsHelpers {
                 break;
         }
         return selector;
+    }
+
+    static getMostRecentRunSelector(bodyElement: HTMLElement): string {
+        const jenkinsVersion = bodyElement.getAttribute("data-version");
+        if (!jenkinsVersion) {
+            throw new Error("I can't determine the Jenkins version!");
+        }
+        const jenkinsSemVer = SemVer.parse(jenkinsVersion);
+        // jenkinsci/jenkins#9148: Rewrite the build history widget by janfaracik
+        // https://github.com/jenkinsci/jenkins/pull/9148
+        if (jenkins2_463.compareTo(jenkinsSemVer) <= 0) {
+            return "#jenkins-build-history .app-builds-container__item__inner__link";
+        }
+        return "tr.build-row a.build-link";
     }
 
     static isInteger(s: string): boolean {

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -51,6 +51,14 @@ test("compare with larger minor", () => {
     assert.equal(y.compareTo(x), 1);
 });
 
+test("compare with larger patch", () => {
+    const x = new SemVer(1, 2, 3);
+    const y = new SemVer(1, 2, 4);
+
+    assert.equal(x.compareTo(y), -1);
+    assert.equal(y.compareTo(x), 1);
+});
+
 test("parse with invalid value", () => {
     const input = "invalid";
 

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -1,0 +1,14 @@
+import { assert, test } from "vitest";
+import { SemVer } from "./SemVer";
+
+test("construct with MAJOR.MINOR.PATCH", () => {
+    const major = 1;
+    const minor = 2;
+    const patch = 3;
+
+    const actual = new SemVer(major, minor, patch);
+
+    assert.equal(actual.major, major);
+    assert.equal(actual.minor, minor);
+    assert.equal(actual.patch, patch);
+});

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -65,6 +65,16 @@ test("parse with invalid value", () => {
     assert.throw(() => SemVer.parse(input));
 });
 
+test("parse with MAJOR.MINOR", () => {
+    const input = "1.2";
+
+    const actual = SemVer.parse(input);
+
+    assert.equal(actual.major, 1);
+    assert.equal(actual.minor, 2);
+    assert.equal(actual.patch, 0);
+});
+
 test("parse with MAJOR.MINOR.PATCH", () => {
     const input = "1.2.3";
 

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -42,3 +42,14 @@ test("parse with MAJOR.MINOR.PATCH", () => {
     assert.equal(actual.minor, 2);
     assert.equal(actual.patch, 3);
 });
+
+test("parse with MAJOR.MINOR.PATCH-PRERELEASE", () => {
+    const input = "1.2.3-SNAPSHOT";
+
+    const actual = SemVer.parse(input);
+
+    assert.equal(actual.major, 1);
+    assert.equal(actual.minor, 2);
+    assert.equal(actual.patch, 3);
+    assert.equal(actual.preRelease, "SNAPSHOT");
+});

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -27,6 +27,15 @@ test("construct with MAJOR.MINOR.PATCH-PRE_RELEASE", () => {
     assert.equal(actual.preRelease, preRelease);
 });
 
+test("compare with larger major", () => {
+    const input = new SemVer(1, 2, 3);
+    const that = new SemVer(2, 2, 3);
+
+    const actual = input.compareTo(that);
+
+    assert.equal(actual, -1);
+});
+
 test("parse with invalid value", () => {
     const input = "invalid";
 

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -27,9 +27,25 @@ test("construct with MAJOR.MINOR.PATCH-PRE_RELEASE", () => {
     assert.equal(actual.preRelease, preRelease);
 });
 
+test("compare when equal", () => {
+    const x = new SemVer(1, 2, 3);
+    const y = new SemVer(1, 2, 3);
+
+    assert.equal(x.compareTo(y), 0);
+    assert.equal(y.compareTo(x), 0);
+});
+
 test("compare with larger major", () => {
     const x = new SemVer(1, 2, 3);
     const y = new SemVer(2, 2, 3);
+
+    assert.equal(x.compareTo(y), -1);
+    assert.equal(y.compareTo(x), 1);
+});
+
+test("compare with larger minor", () => {
+    const x = new SemVer(1, 2, 3);
+    const y = new SemVer(1, 3, 3);
 
     assert.equal(x.compareTo(y), -1);
     assert.equal(y.compareTo(x), 1);

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -28,12 +28,11 @@ test("construct with MAJOR.MINOR.PATCH-PRE_RELEASE", () => {
 });
 
 test("compare with larger major", () => {
-    const input = new SemVer(1, 2, 3);
-    const that = new SemVer(2, 2, 3);
+    const x = new SemVer(1, 2, 3);
+    const y = new SemVer(2, 2, 3);
 
-    const actual = input.compareTo(that);
-
-    assert.equal(actual, -1);
+    assert.equal(x.compareTo(y), -1);
+    assert.equal(y.compareTo(x), 1);
 });
 
 test("parse with invalid value", () => {

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -26,3 +26,9 @@ test("construct with MAJOR.MINOR.PATCH-PRE_RELEASE", () => {
     assert.equal(actual.patch, patch);
     assert.equal(actual.preRelease, preRelease);
 });
+
+test("parse with invalid value", () => {
+    const input = "invalid";
+
+    assert.throw(() => SemVer.parse(input));
+});

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -32,3 +32,13 @@ test("parse with invalid value", () => {
 
     assert.throw(() => SemVer.parse(input));
 });
+
+test("parse with MAJOR.MINOR.PATCH", () => {
+    const input = "1.2.3";
+
+    const actual = SemVer.parse(input);
+
+    assert.equal(actual.major, 1);
+    assert.equal(actual.minor, 2);
+    assert.equal(actual.patch, 3);
+});

--- a/src/SemVer.spec.ts
+++ b/src/SemVer.spec.ts
@@ -12,3 +12,17 @@ test("construct with MAJOR.MINOR.PATCH", () => {
     assert.equal(actual.minor, minor);
     assert.equal(actual.patch, patch);
 });
+
+test("construct with MAJOR.MINOR.PATCH-PRE_RELEASE", () => {
+    const major = 1;
+    const minor = 2;
+    const patch = 3;
+    const preRelease = "SNAPSHOT";
+
+    const actual = new SemVer(major, minor, patch, preRelease);
+
+    assert.equal(actual.major, major);
+    assert.equal(actual.minor, minor);
+    assert.equal(actual.patch, patch);
+    assert.equal(actual.preRelease, preRelease);
+});

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -1,3 +1,5 @@
+const semVerRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/;
+
 export class SemVer {
     readonly major: number;
     readonly minor: number;
@@ -17,6 +19,15 @@ export class SemVer {
     }
 
     static parse(value: string): SemVer {
-        throw new Error(`Can't parse ${value} as a valid SemVer`);
+        const valueMatch = value.match(semVerRegex);
+        if (!valueMatch || !valueMatch.groups) {
+            throw new Error(`Can't parse ${value} as a valid SemVer`);
+        }
+        const valueGroups = valueMatch.groups;
+        const major = Number.parseInt(valueGroups.major, 10);
+        const minor = Number.parseInt(valueGroups.minor, 10);
+        const patch = Number.parseInt(valueGroups.patch, 10);
+
+        return new SemVer(major, minor, patch);
     }
 }

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -30,6 +30,7 @@ export class SemVer {
     }
 
     compareTo(that: SemVer): number {
+        // TODO: this doesn't (yet) compare pre-releases
         return (
             SemVer.compareTo(this.major, that.major) ||
             SemVer.compareTo(this.minor, that.minor) ||

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -30,8 +30,10 @@ export class SemVer {
     }
 
     compareTo(that: SemVer): number {
-        return SemVer.compareTo(this.major, that.major)
-        || Se;
+        return (
+            SemVer.compareTo(this.major, that.major) ||
+            SemVer.compareTo(this.minor, that.minor)
+        );
     }
 
     static parse(value: string): SemVer {

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -32,7 +32,8 @@ export class SemVer {
     compareTo(that: SemVer): number {
         return (
             SemVer.compareTo(this.major, that.major) ||
-            SemVer.compareTo(this.minor, that.minor)
+            SemVer.compareTo(this.minor, that.minor) ||
+            SemVer.compareTo(this.patch, that.patch)
         );
     }
 

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -1,0 +1,12 @@
+
+export class SemVer {
+    readonly major: number;
+    readonly minor: number;
+    readonly patch: number;
+
+    constructor(major: number, minor: number, patch: number) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+}

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -19,6 +19,21 @@ export class SemVer {
         this.preRelease = preRelease;
     }
 
+    static compareTo(x: number, y: number): number {
+        if (x == y) {
+            return 0;
+        }
+        if (x < y) {
+            return -1;
+        }
+        return 1;
+    }
+
+    compareTo(that: SemVer): number {
+        return SemVer.compareTo(this.major, that.major)
+        || Se;
+    }
+
     static parse(value: string): SemVer {
         const valueMatch = value.match(semVerRegex);
         if (!valueMatch || !valueMatch.groups) {

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -1,12 +1,18 @@
-
 export class SemVer {
     readonly major: number;
     readonly minor: number;
     readonly patch: number;
+    readonly preRelease?: string;
 
-    constructor(major: number, minor: number, patch: number) {
+    constructor(
+        major: number,
+        minor: number,
+        patch: number,
+        preRelease?: string
+    ) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
+        this.preRelease = preRelease;
     }
 }

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -1,4 +1,5 @@
-const semVerRegex = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/;
+const semVerRegex =
+    /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<preRelease>.+))?/;
 
 export class SemVer {
     readonly major: number;
@@ -27,7 +28,8 @@ export class SemVer {
         const major = Number.parseInt(valueGroups.major, 10);
         const minor = Number.parseInt(valueGroups.minor, 10);
         const patch = Number.parseInt(valueGroups.patch, 10);
+        const preRelease = valueGroups.preRelease;
 
-        return new SemVer(major, minor, patch);
+        return new SemVer(major, minor, patch, preRelease);
     }
 }

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -1,5 +1,5 @@
 const semVerRegex =
-    /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<preRelease>.+))?/;
+    /(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+)(?:-(?<preRelease>.+))?)?/;
 
 export class SemVer {
     readonly major: number;
@@ -17,6 +17,14 @@ export class SemVer {
         this.minor = minor;
         this.patch = patch;
         this.preRelease = preRelease;
+    }
+
+    static asInteger(value: string): number {
+        const maybeInt = Number.parseInt(value, 10);
+        if (Number.isNaN(maybeInt)) {
+            return 0;
+        }
+        return maybeInt;
     }
 
     static compareTo(x: number, y: number): number {
@@ -44,9 +52,9 @@ export class SemVer {
             throw new Error(`Can't parse ${value} as a valid SemVer`);
         }
         const valueGroups = valueMatch.groups;
-        const major = Number.parseInt(valueGroups.major, 10);
-        const minor = Number.parseInt(valueGroups.minor, 10);
-        const patch = Number.parseInt(valueGroups.patch, 10);
+        const major = SemVer.asInteger(valueGroups.major);
+        const minor = SemVer.asInteger(valueGroups.minor);
+        const patch = SemVer.asInteger(valueGroups.patch);
         const preRelease = valueGroups.preRelease;
 
         return new SemVer(major, minor, patch, preRelease);

--- a/src/SemVer.ts
+++ b/src/SemVer.ts
@@ -15,4 +15,8 @@ export class SemVer {
         this.patch = patch;
         this.preRelease = preRelease;
     }
+
+    static parse(value: string): SemVer {
+        throw new Error(`Can't parse ${value} as a valid SemVer`);
+    }
 }

--- a/src/actions/JenkinsConsole.spec.ts
+++ b/src/actions/JenkinsConsole.spec.ts
@@ -11,7 +11,7 @@ function testNavigate(html: string, url: string): string | null {
     return actual;
 }
 
-test("job page", () => {
+test("job page before 2.463", () => {
     const html = `
 <html>
     <head>
@@ -217,6 +217,235 @@ test("job page", () => {
             </table>
         </div>
     </body>
+</html>`;
+
+    const actual = testNavigate(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/"
+    );
+
+    assert.equal(
+        actual,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/3/consoleFull"
+    );
+});
+
+test("job page at or after 2.463", () => {
+    const html = `
+<html>
+  <head>
+    <title>Project » Repository » Branch [Jenkins]</title>
+  </head>
+  <body
+    data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+    id="jenkins"
+    class="yui-skin-sam two-column jenkins-2.463"
+    data-version="2.463"
+    >
+    <!-- etc., etc... -->
+    <div
+      id="jenkins-build-history"
+      class="app-builds-container__items"
+      >
+      <div
+        data-page-entry-newest="-9223372036854775805"
+        data-page-has-up="false"
+        data-page-has-down="false"
+        data-page-entry-oldest="-9223372036854775807"
+        >
+        <span class="app-builds-container__heading">Today</span>
+        <div
+          page-entry-id="-9223372036854775805"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="In progress"
+            href="/job/Project/job/Repository/job/Branch/3/console"
+            class="app-builds-container__item__icon"
+            title="In progress"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="-256 -256 512 512"
+              >
+              (...)
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/3/"
+              class="app-builds-container__item__inner__link"
+              >
+              #3
+              <span
+                time="1733687566047"
+                class="app-builds-container__item__time"
+                >
+                <div
+                  data-tooltip-append-to-parent="true"
+                  >
+                  7:52 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls">
+              <a
+                class="app-progress-bar app-progress-bar--error"
+                href="/job/Project/job/Repository/job/Branch/3/console"
+                tooltip="Started 30 sec ago
+    Estimated remaining time: N/A"
+                data-tooltip-append-to-parent="true"
+                id=""
+                data-tooltip-template="Started %0 ago
+    Estimated remaining time: %1"
+                title="Started 30 sec ago
+    Estimated remaining time: N/A"
+                >
+                <span style="width: 99%"></span>
+              </a>
+              <a
+                data-tooltip-append-to-parent="true"
+                tooltip="Cancel"
+                data-confirm="Are you sure you want to abort tcu 79 #3?"
+                href="/job/Project/job/Repository/job/Branch/3/stop"
+                class="stop-button-link"
+                title="Cancel"
+                >
+                <span class="jenkins-visually-hidden">Cancel</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  viewBox="0 0 512 512"
+                  >
+                  (...)
+                </svg>
+              </a>
+            </div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/3/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+        <span class="app-builds-container__heading">December 7, 2024</span>
+        <div
+          page-entry-id="-9223372036854775806"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="Success"
+            href="/job/Project/job/Repository/job/Branch/2/console"
+            class="app-builds-container__item__icon"
+            title="Success"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg
+          >
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/2/"
+              class="app-builds-container__item__inner__link"
+              >
+              #2
+              <span
+                time="1733596477775"
+                class="app-builds-container__item__time"
+                >
+                <div
+                  data-tooltip-append-to-parent="true"
+                  tooltip="Took 0.59 sec"
+                  title="Took 0.59 sec"
+                  >
+                  6:34 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls"></div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/2/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+        <div
+          page-entry-id="-9223372036854775807"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="Success"
+            href="/job/Project/job/Repository/job/Branch/1/console"
+            class="app-builds-container__item__icon"
+            title="Success"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/1/"
+              class="app-builds-container__item__inner__link"
+              >
+              #1
+              <span time="1733596470813" class="app-builds-container__item__time">
+                <div
+                  data-tooltip-append-to-parent="true"
+                  tooltip="Took 2.3 sec"
+                  title="Took 2.3 sec"
+                  >
+                  6:34 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls"></div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/1/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>`;
 
     const actual = testNavigate(

--- a/src/actions/JenkinsConsole.ts
+++ b/src/actions/JenkinsConsole.ts
@@ -31,7 +31,8 @@ export class JenkinsConsole extends GoToAction {
                 }
                 return null;
             } else {
-                const mostRecentRunSelector = "tr.build-row a.build-link";
+                const mostRecentRunSelector =
+                    JenkinsHelpers.getMostRecentRunSelector(bodyElement);
                 const anchor = bodyElement.querySelector(mostRecentRunSelector);
                 if (anchor) {
                     const path = anchor.getAttribute("href");

--- a/src/actions/JenkinsConsole.ts
+++ b/src/actions/JenkinsConsole.ts
@@ -31,15 +31,14 @@ export class JenkinsConsole extends GoToAction {
                 }
                 return null;
             } else {
-                const mostRecentRunSelector =
-                    "tr.build-row a.build-status-link";
+                const mostRecentRunSelector = "tr.build-row a.build-link";
                 const anchor = bodyElement.querySelector(mostRecentRunSelector);
                 if (anchor) {
                     const path = anchor.getAttribute("href");
                     if (path) {
                         return JenkinsHelpers.buildUrl(
                             urlString,
-                            path + "Full"
+                            path + "consoleFull"
                         );
                     }
                 }

--- a/src/actions/JenkinsConsole.ts
+++ b/src/actions/JenkinsConsole.ts
@@ -23,9 +23,9 @@ export class JenkinsConsole extends GoToAction {
                 if (anchor) {
                     const path = anchor.getAttribute("href");
                     if (path) {
-                        return (
-                            JenkinsHelpers.buildUrl(urlString, path) +
-                            "consoleFull"
+                        return JenkinsHelpers.buildUrl(
+                            urlString,
+                            path + "consoleFull"
                         );
                     }
                 }

--- a/src/actions/JenkinsNext.spec.ts
+++ b/src/actions/JenkinsNext.spec.ts
@@ -11,7 +11,7 @@ function testNavigate(html: string, url: string): string | null {
     return actual;
 }
 
-test("job page", () => {
+test("job page before 2.463", () => {
     const html = `
 <html>
     <head>
@@ -217,6 +217,235 @@ test("job page", () => {
             </table>
         </div>
     </body>
+</html>`;
+
+    const actual = testNavigate(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/"
+    );
+
+    assert.equal(
+        actual,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/3/"
+    );
+});
+
+test("job page at or after 2.463", () => {
+    const html = `
+<html>
+  <head>
+    <title>Project » Repository » Branch [Jenkins]</title>
+  </head>
+  <body
+    data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+    id="jenkins"
+    class="yui-skin-sam two-column jenkins-2.463"
+    data-version="2.463"
+    >
+    <!-- etc., etc... -->
+    <div
+      id="jenkins-build-history"
+      class="app-builds-container__items"
+      >
+      <div
+        data-page-entry-newest="-9223372036854775805"
+        data-page-has-up="false"
+        data-page-has-down="false"
+        data-page-entry-oldest="-9223372036854775807"
+        >
+        <span class="app-builds-container__heading">Today</span>
+        <div
+          page-entry-id="-9223372036854775805"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="In progress"
+            href="/job/Project/job/Repository/job/Branch/3/console"
+            class="app-builds-container__item__icon"
+            title="In progress"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="-256 -256 512 512"
+              >
+              (...)
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/3/"
+              class="app-builds-container__item__inner__link"
+              >
+              #3
+              <span
+                time="1733687566047"
+                class="app-builds-container__item__time"
+                >
+                <div
+                  data-tooltip-append-to-parent="true"
+                  >
+                  7:52 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls">
+              <a
+                class="app-progress-bar app-progress-bar--error"
+                href="/job/Project/job/Repository/job/Branch/3/console"
+                tooltip="Started 30 sec ago
+    Estimated remaining time: N/A"
+                data-tooltip-append-to-parent="true"
+                id=""
+                data-tooltip-template="Started %0 ago
+    Estimated remaining time: %1"
+                title="Started 30 sec ago
+    Estimated remaining time: N/A"
+                >
+                <span style="width: 99%"></span>
+              </a>
+              <a
+                data-tooltip-append-to-parent="true"
+                tooltip="Cancel"
+                data-confirm="Are you sure you want to abort tcu 79 #3?"
+                href="/job/Project/job/Repository/job/Branch/3/stop"
+                class="stop-button-link"
+                title="Cancel"
+                >
+                <span class="jenkins-visually-hidden">Cancel</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  viewBox="0 0 512 512"
+                  >
+                  (...)
+                </svg>
+              </a>
+            </div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/3/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+        <span class="app-builds-container__heading">December 7, 2024</span>
+        <div
+          page-entry-id="-9223372036854775806"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="Success"
+            href="/job/Project/job/Repository/job/Branch/2/console"
+            class="app-builds-container__item__icon"
+            title="Success"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg
+          >
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/2/"
+              class="app-builds-container__item__inner__link"
+              >
+              #2
+              <span
+                time="1733596477775"
+                class="app-builds-container__item__time"
+                >
+                <div
+                  data-tooltip-append-to-parent="true"
+                  tooltip="Took 0.59 sec"
+                  title="Took 0.59 sec"
+                  >
+                  6:34 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls"></div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/2/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+        <div
+          page-entry-id="-9223372036854775807"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="Success"
+            href="/job/Project/job/Repository/job/Branch/1/console"
+            class="app-builds-container__item__icon"
+            title="Success"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/1/"
+              class="app-builds-container__item__inner__link"
+              >
+              #1
+              <span time="1733596470813" class="app-builds-container__item__time">
+                <div
+                  data-tooltip-append-to-parent="true"
+                  tooltip="Took 2.3 sec"
+                  title="Took 2.3 sec"
+                  >
+                  6:34 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls"></div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/1/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>`;
 
     const actual = testNavigate(

--- a/src/actions/JenkinsNext.ts
+++ b/src/actions/JenkinsNext.ts
@@ -23,7 +23,8 @@ export class JenkinsNext extends GoToAction {
                     const rebuiltPath = urlParts.join("/");
                     return JenkinsHelpers.buildUrl(urlString, rebuiltPath);
                 } else {
-                    const mostRecentRunSelector = "tr.build-row a.build-link";
+                    const mostRecentRunSelector =
+                        JenkinsHelpers.getMostRecentRunSelector(bodyElement);
                     const anchor = bodyElement.querySelector(
                         mostRecentRunSelector
                     );


### PR DESCRIPTION
## Summary

jenkinsci/jenkins#9148 changed the "build history widget" as of Jenkins 2.463 from an HTML `table` to a hierarchy of `div`.  It seemed prudent to implement rudimentary version parsing and comparison to decide which CSS selector to use so that the legacy and new versions would be supported.

Fixes #79.