### PR TITLE
fix: improve ServiceNow parsing

### DIFF
--- a/src/parsers/ServiceNow.spec.ts
+++ b/src/parsers/ServiceNow.spec.ts
@@ -166,3 +166,50 @@ test("should parse a ticket page", () => {
         "TCKT000042: This is as close to the title as we'll get"
     );
 });
+
+test("layout as of late 2024", () => {
+    const html = `
+<html>
+    <head>,
+        <title>Organization ServiceNow</title>
+    </head>
+    <body
+        class="firefox ng-scope fixed-header fixed-footer"
+        accessibility="false"
+        >
+        <div
+            class="sp-page-root page flex-column sp-can-animate"
+            style=""
+            >
+            <div
+                class="form-control no-padder no-border no-bg ng-binding"
+                id="data.number.name"
+                >
+                I am the ticket ID
+            </div>
+            <h2
+                class="inline m-n m-r-sm ng-binding"
+                style="word-break: break-word;"
+                id="short-desc"
+                >
+                I am the title/summary
+            </h2>
+        </div>
+    </body>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://example.service-now.com/csp/?id=ticket&table=sc_req_item&sys_id=36c7352a9798ed505943fae3a253af5e"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://example.service-now.com/csp/?id=ticket&table=sc_req_item&sys_id=36c7352a9798ed505943fae3a253af5e"
+    );
+    assert.equal(
+        actual?.text,
+        "I am the ticket ID: I am the title/summary"
+    );
+});

--- a/src/parsers/ServiceNow.ts
+++ b/src/parsers/ServiceNow.ts
@@ -33,7 +33,7 @@ export class ServiceNow extends AbstractParser {
                         }
                     }
                 }
-                if (!subject || subject === undefined) {
+                if (!subject) {
                     const h2Element: HTMLElement | null =
                         doc.querySelector("#short-desc");
                     if (h2Element) {

--- a/src/parsers/ServiceNow.ts
+++ b/src/parsers/ServiceNow.ts
@@ -1,79 +1,60 @@
 import { AbstractParser } from "./AbstractParser";
 import { Link } from "../Link";
 
-const snUrlRegex = /https:\/\/(?<host>[^/]+)\/esc\/\?id=(?<rest>.+)/;
 export class ServiceNow extends AbstractParser {
     parseLink(doc: Document, url: string): Link | null {
-        const snUrlMatch = url.match(snUrlRegex);
-        if (snUrlMatch && snUrlMatch.groups) {
+        const ticketNumberSelectors = [
+            "#data\\.number\\.name",
+            "h2.ticket-number",
+        ];
+        const ticketNumberElement = doc.querySelector(ticketNumberSelectors.join(", "));
+        if (ticketNumberElement) {
             var linkText = ``;
-            const divElement: HTMLElement | null = doc.querySelector(
-                "#data\\.number\\.name"
-            );
-            if (divElement) {
-                const incidentNumber = divElement.textContent;
-                if (incidentNumber) {
-                    linkText += incidentNumber.trim();
-                }
+            const ticketNumber = ticketNumberElement.textContent;
+            if (ticketNumber) {
+                linkText += ticketNumber.trim();
+
                 var subject: string | undefined | null;
-                // #variables-toggle > div:nth-child(3) > label > b
                 const variablesToggle: HTMLElement | null =
                     doc.querySelector("#variables-toggle");
                 if (variablesToggle) {
-                    const labels =
+                    const bolds =
                         variablesToggle.querySelectorAll("div > label > b");
-                    for (let i = 0; i < labels.length; i++) {
-                        const bold = labels.item(i);
+                    for (let i = 0; i < bolds.length; i++) {
+                        const bold = bolds.item(i);
                         const boldText = bold.textContent?.trim();
                         if ("Subject" == boldText) {
                             const parentDiv = bold.parentElement?.parentElement;
                             const span =
                                 parentDiv?.querySelector("div > div> span");
                             subject = span?.textContent?.trim();
+                            break;
                         }
                     }
                 }
+                // only consider these as a last resort, because sometimes they contain
+                // useless text and the real subject/summary was in the "variables-toggle" element
                 if (!subject) {
-                    const h2Element: HTMLElement | null =
-                        doc.querySelector("#short-desc");
-                    if (h2Element) {
-                        subject = h2Element.textContent;
+                    const subjectSelectors = [
+                        "#short-desc",
+                        "p.ticket-desc",
+                    ];
+                    const subjectElement = doc.querySelector(subjectSelectors.join(", "));
+                    if (subjectElement) {
+                        subject = subjectElement.textContent;
                     }
                 }
                 if (subject) {
                     linkText += `: ${subject.trim()}`;
                 }
-            }
-            const result: Link = {
-                text: linkText,
-                destination: url,
-            };
-            return result;
-        } else {
-            // Does it look like a ServiceNow page?
-            const divElement: HTMLElement | null = doc.querySelector(
-                "body div.sp-page-root"
-            );
-            if (divElement) {
-                const ticketNumberHeading: HTMLHeadingElement | null =
-                    divElement.querySelector("h2.ticket-number");
-                const ticketDescParagraph: HTMLParagraphElement | null =
-                    divElement.querySelector("p.ticket-desc");
-                if (ticketNumberHeading && ticketDescParagraph) {
-                    const ticketNumber = ticketNumberHeading.textContent;
-                    const ticketDesc = ticketDescParagraph.textContent;
-                    const linkText = `${ticketNumber}: ${ticketDesc}`;
-                    const result: Link = {
-                        text: linkText,
-                        destination: url,
-                    };
-                    return result;
-                } else {
-                    return null;
-                }
-            } else {
-                return null;
+
+                const result: Link = {
+                    text: linkText,
+                    destination: url,
+                };
+                return result;
             }
         }
+        return null;
     }
 }


### PR DESCRIPTION
I noticed we were keying off of the URL for half of the scenarios when it's more reliable to key off of the elements we'll be querying via selectors and it unlocked the new scenario automatically.

Resolves #80.