### PR TITLE
fix: only match anchors, skipping pending runs

### DIFF
--- a/src/JenkinsHelpers.spec.ts
+++ b/src/JenkinsHelpers.spec.ts
@@ -55,7 +55,7 @@ test("getMostRecentRunSelector at 2.463", () => {
 
     assert.equal(
         actual,
-        "#jenkins-build-history .app-builds-container__item__inner__link"
+        "#jenkins-build-history a.app-builds-container__item__inner__link"
     );
 });
 
@@ -80,7 +80,7 @@ test("getMostRecentRunSelector at 2.479.2", () => {
 
     assert.equal(
         actual,
-        "#jenkins-build-history .app-builds-container__item__inner__link"
+        "#jenkins-build-history a.app-builds-container__item__inner__link"
     );
 });
 

--- a/src/JenkinsHelpers.ts
+++ b/src/JenkinsHelpers.ts
@@ -43,7 +43,7 @@ export class JenkinsHelpers {
         // jenkinsci/jenkins#9148: Rewrite the build history widget by janfaracik
         // https://github.com/jenkinsci/jenkins/pull/9148
         if (jenkins2_463.compareTo(jenkinsSemVer) <= 0) {
-            return "#jenkins-build-history .app-builds-container__item__inner__link";
+            return "#jenkins-build-history a.app-builds-container__item__inner__link";
         }
         return "tr.build-row a.build-link";
     }

--- a/src/actions/JenkinsNext.spec.ts
+++ b/src/actions/JenkinsNext.spec.ts
@@ -459,6 +459,219 @@ test("job page at or after 2.463", () => {
     );
 });
 
+test("job page, v2.479.2, w/pending run", () => {
+    const html = `
+<html>
+  <head>
+    <title>Project » Repository » Branch [Jenkins]</title>
+  </head>
+  <body
+    data-model-type="org.jenkinsci.plugins.workflow.job.WorkflowRun"
+    id="jenkins"
+    class="yui-skin-sam two-column jenkins-2.479.2"
+    data-version="2.479.2"
+    >
+    <!-- etc., etc... -->
+    <div
+      id="jenkins-build-history"
+      class="app-builds-container__items"
+      >
+      <div
+        data-page-entry-newest="3"
+        data-page-has-up="false"
+        data-page-has-down="false"
+        data-page-entry-oldest="-9223372036854775807"
+        >
+        <span class="app-builds-container__heading">Pending</span>
+        <div
+          page-entry-id="3"
+          class="app-builds-container__item app-builds-container__item--not-interactable"
+          >
+          <div class="app-builds-container__item__icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </div>
+          <div class="app-builds-container__item__inner">
+            <div class="app-builds-container__item__inner__link">#5</div>
+            <div class="app-builds-container__item__inner__controls">
+              <a
+                data-tooltip-append-to-parent="true"
+                tooltip="Cancel"
+                href="/queue/cancelItem?id=3"
+                class="stop-button-link"
+                title="Cancel"
+                >
+                <span class="jenkins-visually-hidden">Cancel</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  viewBox="0 0 512 512"
+                  >
+                  (...)
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div class="app-builds-container__item__description">Build #4 is already
+            in progress (ETA: N/A)
+          </div>
+        </div>
+        <span class="app-builds-container__heading">December 30, 2024</span>
+        <div
+          page-entry-id="-9223372036854775804"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="In progress"
+            href="/job/Project/job/Repository/job/Branch/4/console"
+            class="app-builds-container__item__icon"
+            title="In progress"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="-256 -256 512 512"
+              >
+              (...)
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/4/"
+              class="app-builds-container__item__inner__link"
+              >
+              #4
+              <span
+                time="1735520031821"
+                class="app-builds-container__item__time"
+                >
+                <div data-tooltip-append-to-parent="true">12:53 AM</div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls">
+              <a
+                class="app-progress-bar  "
+                href="/job/Project/job/Repository/job/Branch/4/console"
+                tooltip="Started 48 sec ago
+     Estimated remaining time: N/A"
+                data-tooltip-append-to-parent="true"
+                id=""
+                data-tooltip-template="Started %0 ago
+     Estimated remaining time: %1"
+                title="Started 48 sec ago
+     Estimated remaining time: N/A"
+                >
+                <span style="width: 99%;"></span>
+              </a>
+              <a
+                data-tooltip-append-to-parent="true"
+                tooltip="Cancel"
+                data-confirm="Are you sure you want to abort Project » Repository » tcu 79 #4?"
+                href="/job/Project/job/Repository/job/Branch/4/stop"
+                class="stop-button-link" title="Cancel"
+                >
+                <span class="jenkins-visually-hidden">Cancel</span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                  viewBox="0 0 512 512"
+                  >
+                  (...)
+                </svg>
+              </a>
+            </div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/4/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+        <span class="app-builds-container__heading">December 8, 2024</span>
+        <div
+          page-entry-id="-9223372036854775805"
+          class="app-builds-container__item"
+          >
+          <a
+            data-tooltip-append-to-parent="true"
+            tooltip="Success"
+            href="/job/Project/job/Repository/job/Branch/3/console"
+            class="app-builds-container__item__icon"
+            title="Success"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </a>
+          <div class="app-builds-container__item__inner">
+            <a
+              href="/job/Project/job/Repository/job/Branch/3/"
+              class="app-builds-container__item__inner__link"
+              >
+              #3
+              <span
+                time="1733687566047"
+                class="app-builds-container__item__time"
+                >
+                <div
+                  data-tooltip-append-to-parent="true"
+                  tooltip="Took 36 sec"
+                  title="Took 36 sec"
+                  >
+                  7:52 PM
+                </div>
+              </span>
+            </a>
+            <div class="app-builds-container__item__inner__controls"></div>
+          </div>
+          <button
+            class="jenkins-card__reveal jenkins-jumplist-link"
+            data-href="/job/Project/job/Repository/job/Branch/3/"
+            aria-expanded="false"
+            >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+              viewBox="0 0 512 512"
+              >
+              (...)
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+    const actual = testNavigate(
+        html,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/"
+    );
+
+    assert.equal(
+        actual,
+        "http://localhost:8080/job/Project/job/Repository/job/Branch/4/"
+    );
+});
+
 test("run page", () => {
     const html = `
 <html>


### PR DESCRIPTION
The `app-builds-container__item__inner__link` class is applied to a `div` when there's a pending run, but we want the first `a` with that class.