### PR TITLE
fix: GitHub link to a line in a file

### DIFF
--- a/src/parsers/GitHub.spec.ts
+++ b/src/parsers/GitHub.spec.ts
@@ -183,3 +183,26 @@ test("should parse a GitHub source code link page with refSpec containing a slas
         "src/index.ts at release/1.1 in olivierdagenais/tampermonkey-copy-url"
     );
 });
+test("should parse a GitHub link to a line", () => {
+    const html = `
+<html>
+    <head>
+        <title>workflow-durable-task-step-plugin/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java at 1317.v5337e0c1fe28 · jenkinsci/workflow-durable-task-step-plugin</title>
+    </head>
+</html>`;
+
+    const actual = testParseLink(
+        html,
+        "https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/1317.v5337e0c1fe28/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L498"
+    );
+
+    assert.notEqual(actual, null);
+    assert.equal(
+        actual?.destination,
+        "https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/1317.v5337e0c1fe28/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L498"
+    );
+    assert.equal(
+        actual?.text,
+        "line 498 of src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java at 1317.v5337e0c1fe28 in jenkinsci/workflow-durable-task-step-plugin"
+    );
+});

--- a/src/parsers/GitHub.ts
+++ b/src/parsers/GitHub.ts
@@ -19,10 +19,20 @@ export class GitHub extends AbstractParser {
                 if (blobTitleMatch && blobTitleMatch.groups) {
                     const blobTitleGroups = blobTitleMatch.groups;
                     const refSpec = blobTitleGroups.refSpec;
-                    const path = refSpecAndPath.substring(
+                    const pathAndMaybeLine = refSpecAndPath.substring(
                         refSpec.length + 1 /* the slash */
                     );
-                    titleString = `${path} at ${refSpec} in ${blobUrlGroups.userOrOrg}/${blobUrlGroups.repo}`;
+                    const indexOfHash = pathAndMaybeLine.indexOf("#L");
+                    let path : string = "";
+                    let prefix : string = "";
+                    if (indexOfHash > -1) {
+                        path = pathAndMaybeLine.substring(0, indexOfHash);
+                        prefix = "line " + pathAndMaybeLine.substring(indexOfHash + 2) + " of ";
+                    }
+                    else {
+                        path = pathAndMaybeLine;
+                    }
+                    titleString = `${prefix}${path} at ${refSpec} in ${blobUrlGroups.userOrOrg}/${blobUrlGroups.repo}`;
                 }
             } else {
                 const numberedUrlRegex =


### PR DESCRIPTION
Fixes #53

# Manual testing

## GIVEN
1. Ran `npm run build`.
2. Copy-pasted the generated `userscript/index.user.js` over top of the `tampermonkey-copy-url` user script in my browser (making sure my editor was decoding it as UTF-8) and saved it.
3. Navigated to https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/1317.v5337e0c1fe28/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L498

## WHEN

I activated the "Copy" action for Markdown (`Ctrl+0`)

## THEN

1. The following pop-up appeared: \
    ![image](https://github.com/user-attachments/assets/14080146-3fd8-4d64-ac24-f2d455ac4500)
2. The contents of the clipboard were:
  ```markdown
  [line 498 of src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java at 1317.v5337e0c1fe28 in jenkinsci/workflow-durable-task-step-plugin](https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/1317.v5337e0c1fe28/src/main/java/org/jenkinsci/plugins/workflow/steps/durable_task/DurableTaskStep.java#L498)
  ```

Mission accomplished!