### PR TITLE
fix: tell SciTE about the output file's encoding for manual testing

### DIFF
--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -60,7 +60,9 @@ export function generateHeader() {
     // The regular expression used to remove the dependency version string prefix.
     const dependencyVersionRegExp = /^[\^~]/;
     // Userscript's header.
-    const headers = ["// ==UserScript=="];
+    const headers = [
+        "// ==UserScript==",
+    ];
 
     /**
      * Add userscript header's name.

--- a/plugins/userscript.plugin.ts
+++ b/plugins/userscript.plugin.ts
@@ -62,6 +62,7 @@ export function generateHeader() {
     // Userscript's header.
     const headers = [
         "// ==UserScript==",
+        "// coding: utf-8",
     ];
 
     /**


### PR DESCRIPTION
Manual testing had one hidden step: after opening the `userscript/index.js` file with SciTE, I needed to go to: **File** > **Encoding** > **UTF-8** otherwise subtle defects would be exposed.

I am now emitting a special comment containing a "coding cookie" recognized by SciTE as per https://www.scintilla.org/SciTEDoc.html#Encodings to make sure it opens the file with UTF-8 encoding right away.

After running `npm run build`, when I now open the output file with SciTE, it's in UTF-8 mode and I can copy-paste it to the Tampermonkey editor!